### PR TITLE
Add wireless dongle support (Steam Controller Puck)

### DIFF
--- a/src/hid/HidDevice.cpp
+++ b/src/hid/HidDevice.cpp
@@ -49,8 +49,8 @@ std::vector<std::wstring> HidDevice::Enumerate(uint16_t vid, uint16_t pid, uint1
         HIDD_ATTRIBUTES attrs{};
         attrs.Size = sizeof(attrs);
         bool match = HidD_GetAttributes(h, &attrs)
-                  && attrs.VendorID  == vid
-                  && attrs.ProductID == pid;
+                  && attrs.VendorID == vid
+                  && (pid == 0 || attrs.ProductID == pid);
 
         if (match && usagePage != 0) {
             PHIDP_PREPARSED_DATA preparsed;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,11 @@
 #include <Windows.h>
+#include <hidsdi.h>
+#include <hidpi.h>
 #include <csignal>
 #include <cstdio>
 #include <cstring>
 #include <climits>
+#include "hid/HidDevice.h"
 #include "steam/SteamController.h"
 
 static SteamController* g_controller = nullptr;
@@ -122,12 +125,53 @@ static void PrintState42Diff(const uint8_t* buf, size_t n) {
 // main
 // ---------------------------------------------------------------------------
 
+static void EnumerateAllValveDevices() {
+    printf("=== All Valve HID interfaces (VID=28DE) ===\n");
+    auto paths = HidDevice::Enumerate(SteamController::VALVE_VID, 0);
+    if (paths.empty()) {
+        printf("  None found.\n\n");
+        return;
+    }
+
+    for (auto const& path : paths) {
+        HANDLE h = CreateFileW(path.c_str(), 0,
+                               FILE_SHARE_READ | FILE_SHARE_WRITE,
+                               nullptr, OPEN_EXISTING, 0, nullptr);
+        if (h == INVALID_HANDLE_VALUE) continue;
+
+        HIDD_ATTRIBUTES attrs{};
+        attrs.Size = sizeof(attrs);
+        HidD_GetAttributes(h, &attrs);
+
+        wchar_t productBuf[128] = L"(unknown)";
+        HidD_GetProductString(h, productBuf, sizeof(productBuf));
+
+        uint16_t usagePage = 0, usage = 0;
+        PHIDP_PREPARSED_DATA preparsed;
+        if (HidD_GetPreparsedData(h, &preparsed)) {
+            HIDP_CAPS caps{};
+            if (HidP_GetCaps(preparsed, &caps) == HIDP_STATUS_SUCCESS) {
+                usagePage = caps.UsagePage;
+                usage     = caps.Usage;
+            }
+            HidD_FreePreparsedData(preparsed);
+        }
+
+        printf("  PID=%04X  UsagePage=%04X  Usage=%04X  \"%ls\"\n",
+               attrs.ProductID, usagePage, usage, productBuf);
+        CloseHandle(h);
+    }
+    printf("\n");
+}
+
 int main() {
     signal(SIGINT,  OnSignal);
     signal(SIGTERM, OnSignal);
 
     printf("=== SteamProbe — 2026 Steam Controller (VID=28DE PID=1302) ===\n\n");
     printf("NOTE: Close Steam before running this tool.\n\n");
+
+    EnumerateAllValveDevices();
 
     SteamController controller;
     g_controller = &controller;

--- a/src/steam/SteamController.cpp
+++ b/src/steam/SteamController.cpp
@@ -32,17 +32,30 @@ static void BuildCmd(uint8_t (&buf)[64], uint8_t cmd,
 // ---------------------------------------------------------------------------
 
 bool SteamController::Open() {
-    auto paths = HidDevice::Enumerate(VALVE_VID, SC2026_PID, VENDOR_USAGE_PAGE);
-    if (paths.empty()) {
-        printf("No Steam Controller found (VID=%04X PID=%04X UsagePage=%04X).\n",
-               VALVE_VID, SC2026_PID, VENDOR_USAGE_PAGE);
-        return false;
+    for (uint16_t pid : { SC2026_PID, SC2026_DONGLE_PID }) {
+        auto paths = HidDevice::Enumerate(VALVE_VID, pid, VENDOR_USAGE_PAGE);
+        if (paths.empty()) continue;
+
+        // For the wired controller there is only one interface; for the dongle
+        // there are up to four slots (one per paired controller). Try each in
+        // order and use the first that produces a live input report.
+        for (auto const& path : paths) {
+            if (!m_device.Open(path)) continue;
+
+            uint8_t buf[64];
+            size_t n = m_device.ReadInputReport(buf, sizeof(buf), /*timeoutMs=*/500);
+            if (n > 0 && buf[0] == REPORT_STATE) {
+                printf("Active interface found for PID=%04X.\n", pid);
+                return true;
+            }
+
+            m_device.Close();
+        }
     }
 
-    printf("Found %zu interface(s). Opening: ", paths.size());
-    wprintf(L"%s\n", paths[0].c_str());
-
-    return m_device.Open(paths[0]);
+    printf("No Steam Controller found (wired PID=%04X or dongle PID=%04X).\n",
+           SC2026_PID, SC2026_DONGLE_PID);
+    return false;
 }
 
 void SteamController::Close() {

--- a/src/steam/SteamController.h
+++ b/src/steam/SteamController.h
@@ -6,8 +6,9 @@
 
 class SteamController {
 public:
-    static constexpr uint16_t VALVE_VID  = 0x28DE;
-    static constexpr uint16_t SC2026_PID = 0x1302;
+    static constexpr uint16_t VALVE_VID        = 0x28DE;
+    static constexpr uint16_t SC2026_PID       = 0x1302;  // wired USB
+    static constexpr uint16_t SC2026_DONGLE_PID = 0x1304; // wireless dongle ("Steam Controller Puck")
 
     // HID Usage Page for the vendor collection that carries all game input.
     static constexpr uint16_t VENDOR_USAGE_PAGE = 0xFF00;


### PR DESCRIPTION
## Summary

- Adds `SC2026_DONGLE_PID = 0x1304` constant for the Steam Controller Puck (wireless dongle)
- `Open()` now scans all `FF00/0001` HID interfaces for both wired (`0x1302`) and dongle (`0x1304`) PIDs
- Selects the first interface that responds with a live `0x42` STATE report (500 ms timeout), fixing lizard mode not being disabled on wireless connections

## Why this was broken

The dongle exposes up to 4 HID interfaces — one per controller slot. The old code picked `paths[0]` unconditionally, which could be an empty slot. Feature reports sent to an empty slot are silently ignored by the firmware, so `DisableLizardMode()` appeared to succeed but had no effect.

## Test plan

- [x] Wired controller (PID=0x1302) still connects and disables lizard mode
- [x] Wireless dongle (PID=0x1304) connects, active slot is detected, lizard mode disabled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)