### PR TITLE
Fix firmware compatibility: REPORT_STATE 0x42 to 0x45

### DIFF
--- a/src/app/VirtualController.cpp
+++ b/src/app/VirtualController.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 // ---------------------------------------------------------------------------
-// Report translation — 0x42 → XUSB_REPORT
+// Report translation — 0x45 → XUSB_REPORT
 // ---------------------------------------------------------------------------
 
 static XUSB_REPORT Translate(const uint8_t* buf, size_t n) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ static constexpr uint8_t AXIS_THRESHOLD = 0;   // any idle movement → treat as
 static constexpr bool FORCE_SHOW_BYTES_10_11 = false;  // left joystick X
 static constexpr bool FORCE_SHOW_BYTES_12_13 = false;  // left joystick Y
 static constexpr bool FORCE_SHOW_BYTES_14_15 = false;  // right joystick Y
-static constexpr bool FORCE_SHOW_BYTES_16_17 = true;  // right joystick X
+static constexpr bool FORCE_SHOW_BYTES_16_17 = false;  // right joystick Y
 
 struct ByteStats {
     uint8_t lo  = 0xFF;

--- a/src/steam/SteamController.cpp
+++ b/src/steam/SteamController.cpp
@@ -49,6 +49,12 @@ bool SteamController::Open() {
                 return true;
             }
 
+            if (n > 0)
+                printf("Unexpected report ID 0x%02X on PID=%04X (expected 0x%02X) — possible firmware mismatch.\n",
+                       buf[0], pid, REPORT_STATE);
+            else
+                printf("Read timeout on PID=%04X vendor interface — no active controller on this slot.\n", pid);
+
             m_device.Close();
         }
     }

--- a/src/steam/SteamController.h
+++ b/src/steam/SteamController.h
@@ -14,10 +14,9 @@ public:
     static constexpr uint16_t VENDOR_USAGE_PAGE = 0xFF00;
 
     // Input report IDs (device → host)
-    static constexpr uint8_t REPORT_STATE         = 0x42;  // 53 bytes: main controller state
+    static constexpr uint8_t REPORT_STATE         = 0x45;  // 53 bytes: main controller state (changed from 0x42 in firmware update)
     static constexpr uint8_t REPORT_SECONDARY      = 0x43;  // 14 bytes: gyro / secondary state
     static constexpr uint8_t REPORT_STATUS         = 0x44;  //  5 bytes: battery / connection
-    static constexpr uint8_t REPORT_EXTENDED       = 0x45;  // 45 bytes: extended sensor state
     static constexpr uint8_t REPORT_UNKNOWN_7B     = 0x7B;  // 12 bytes: TBD
     static constexpr uint8_t REPORT_UNKNOWN_79     = 0x79;  //  1 byte:  TBD
 
@@ -41,7 +40,7 @@ public:
     static constexpr uint8_t TRACKPAD_NONE               = 0x00;
 
     // ---------------------------------------------------------------------------
-    // Input report layout — 0x42 STATE report (buf[0] = 0x42)
+    // Input report layout — 0x45 STATE report (buf[0] = 0x45)
     // ---------------------------------------------------------------------------
 
     // buf[01]       — 8-bit sequence counter (wraps 0xFF → 0x00)


### PR DESCRIPTION
## Summary

A Valve firmware update changed the primary STATE report ID from `0x42` to `0x45`, breaking controller input entirely. This incorporates the fix from [@falten's fork](https://github.com/falten/SteamlessController/pull/1).

- `REPORT_STATE` updated from `0x42` to `0x45` in `SteamController.h`
- Removed now-redundant `REPORT_EXTENDED = 0x45` constant (it was the same value)
- Updated the input report layout comment to reference `0x45`
- Updated the `VirtualController.cpp` translation comment to match
- Added better probe diagnostics in `Open()` — now distinguishes firmware mismatch (unexpected report ID) from an empty dongle slot (read timeout)
- Fixed stale `FORCE_SHOW_BYTES_16_17` debug flag in SteamProbe (was `true` with wrong label, now `false` with correct label "right joystick Y")

## Test plan

- [ ] Controller connects and Steamless Mode activates on updated firmware
- [ ] Wired and wireless dongle both work
- [ ] All buttons, sticks, triggers map correctly to virtual Xbox controller

Generated with [Claude Code](https://claude.com/claude-code)
