### PR TITLE
Fix ViGEmBus silent installer arguments

### DIFF
--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -22,6 +22,7 @@ AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
 UninstallDisplayIcon={app}\{#MyAppExeName}
+SourceDir=..
 ; "ArchitecturesAllowed=x64compatible" specifies that Setup cannot run
 ; on anything but x64 and Windows 11 on Arm.
 ArchitecturesAllowed=x64compatible
@@ -34,7 +35,7 @@ DisableProgramGroupPage=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only).
 ;PrivilegesRequired=lowest
 OutputBaseFilename=SteamlessController-Setup
-SetupIconFile=C:\Users\ddeve\iCloudDrive\Development\SteamlessController\resources\SteamControllerON.ico
+SetupIconFile=resources\SteamControllerON.ico
 SolidCompression=yes
 WizardStyle=modern
 
@@ -45,14 +46,15 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "C:\Users\ddeve\iCloudDrive\Development\SteamlessController\build\release\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\ddeve\iCloudDrive\Development\SteamlessController\resources\{#ViGEmSetup}"; DestDir: "{tmp}"; Flags: deleteafterinstall
+Source: "build\release\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "resources\{#ViGEmSetup}"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Icons]
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{tmp}\{#ViGEmSetup}"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing ViGEmBus driver..."; Flags: waituntilterminated runascurrentuser
+; ViGEmBus uses MSI-style silent switches; /install is rejected by the 1.22.0 bootstrapper.
+Filename: "{tmp}\{#ViGEmSetup}"; Parameters: "/qn /norestart"; StatusMsg: "Installing ViGEmBus driver..."; Flags: waituntilterminated
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 


### PR DESCRIPTION
## Summary

Fixes #24.

Updates the Inno Setup installer so it can install the bundled ViGEmBus dependency successfully and be rebuilt from a normal clone:

- replaces the rejected `/install /quiet` arguments with ViGEmBus' documented silent install switch `/qn`
- removes `runascurrentuser` so the driver installer can run in the elevated setup context
- changes hardcoded local maintainer paths to repo-relative installer paths via `SourceDir=..`

## Why

SteamlessController 1.5 setup can show an `Invalid command line` dialog while the installer status says `Installing ViGEmBus driver...`. The bundled ViGEmBus 1.22.0 bootstrapper rejects `/install`; ViGEm's release notes document `/qn` for silent redistribution.

While testing the fix, the installer script also could not be compiled from a normal clone because the app exe, icon, and ViGEmBus payload paths pointed at `C:\Users\ddeve\iCloudDrive\Development\SteamlessController\...`.

## Testing

Performed on Windows 11 Pro 64-bit (`10.0.26200`):

- Built `SteamlessController.exe` with Visual Studio 2022 Build Tools/CMake.
- Downloaded `ViGEmBus_1.22.0_x64_x86_arm64.exe` into `resources`.
- Compiled the installer with Inno Setup 6.7.3 from a fresh clone path.
- Uninstalled SteamlessController 1.5.
- Uninstalled existing ViGEmBus 1.21.442 via MSI.
- Verified no SteamlessController/ViGEm uninstall entries remained.
- Verified no matching Nefarius virtual bus device remained via `pnputil`.
- Ran the patched installer silently with logging.
- Confirmed installer exit code `0`.
- Confirmed Inno log ran `ViGEmBus_1.22.0_x64_x86_arm64.exe /qn /norestart` with process exit code `0`.
- Confirmed registry now shows SteamlessController 1.5 and ViGEmBus 1.22.0.
- Confirmed `Nefarius Virtual Gamepad Emulation Bus` is present and `Started` via `pnputil`.
- Ran `git diff --check`.