### PR TITLE
Add DS4 gyro/touchpad forwarding, battery status, and enhanced haptics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,14 +29,14 @@ endif()
 
 # ViGEmClient (built from source, static)
 add_library(ViGEmClient STATIC
-    third_party/ViGEmClient-1.16.18.0/src/ViGEmClient.cpp
+    third_party/ViGEmClient-b66d02d/src/ViGEmClient.cpp
 )
 target_include_directories(ViGEmClient PUBLIC
-    third_party/ViGEmClient-1.16.18.0/include
+    third_party/ViGEmClient-b66d02d/include
 )
 target_link_libraries(ViGEmClient PUBLIC setupapi)
 if (MSVC)
-    target_compile_options(ViGEmClient PRIVATE /W0 /utf-8)
+    target_compile_options(ViGEmClient PRIVATE /W0 /utf-8 /wd4828)
 endif()
 
 # RawGameController diagnostic probe (WinRT)

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -22,6 +22,12 @@ struct ControllerManager::Slot {
     std::atomic<bool>                  readRunning{false};
     bool                               gameModeActive = false;
 
+    // Haptic edge-detection state — fire a haptic on first touch/click each gesture.
+    bool hapticWasRightTouching = false;
+    bool hapticWasLeftTouching  = false;
+    bool hapticWasRightClicked  = false;
+    bool hapticWasLeftClicked   = false;
+
     Slot() = default;
     Slot(const Slot&) = delete;
     Slot& operator=(const Slot&) = delete;
@@ -126,14 +132,18 @@ void ControllerManager::DisableGameMode() {
 
 void ControllerManager::SetTrackpadMouseEnabled(bool enabled) {
     m_trackpadMouseEnabled = enabled;
-    for (auto& slot : m_slots)
+    for (auto& slot : m_slots) {
         slot->trackpad.SetTrackpadEnabled(enabled);
+        if (slot->vc) slot->vc->SetTrackpadMouseClaim(enabled, m_useLeftTrackpad);
+    }
 }
 
 void ControllerManager::SetUseLeftTrackpad(bool enabled) {
     m_useLeftTrackpad = enabled;
-    for (auto& slot : m_slots)
+    for (auto& slot : m_slots) {
         slot->trackpad.SetUseLeftTrackpad(enabled);
+        if (slot->vc) slot->vc->SetTrackpadMouseClaim(m_trackpadMouseEnabled, enabled);
+    }
 }
 
 void ControllerManager::SetBackButtonConfig(const BackButtonConfig& cfg) {
@@ -226,10 +236,7 @@ void ControllerManager::EnableGameModeSlot(Slot& slot, bool& vigemMissingOut) {
     slot.vc = std::make_unique<VirtualController>(
         m_controllerPlatform,
         [sc = slot.sc.get()](uint8_t largeMotor, uint8_t smallMotor) {
-            if (!sc->IsOpen()) return;
-            const uint16_t leftSpeed  = static_cast<uint16_t>(static_cast<uint32_t>(largeMotor) * 257u);
-            const uint16_t rightSpeed = static_cast<uint16_t>(static_cast<uint32_t>(smallMotor) * 257u);
-            sc->SetRumble(leftSpeed, rightSpeed);
+            if (sc->IsOpen()) sc->SetRumble(largeMotor, smallMotor);
         });
     if (!slot.vc->IsValid()) {
         if (slot.vc->IsDriverMissing()) vigemMissingOut = true;
@@ -237,6 +244,10 @@ void ControllerManager::EnableGameModeSlot(Slot& slot, bool& vigemMissingOut) {
         slot.sc->EnableLizardMode();
         return;
     }
+
+    if (m_controllerPlatform == ControllerPlatform::PlayStation)
+        slot.sc->SetImuEnabled(true);
+    slot.vc->SetTrackpadMouseClaim(m_trackpadMouseEnabled, m_useLeftTrackpad);
 
     slot.gameModeActive = true;
     slot.trackpad.Reset();
@@ -280,10 +291,36 @@ void ControllerManager::ReadLoop(Slot* slot) {
     while (slot->readRunning) {
         size_t n = slot->sc->ReadReport(buf, sizeof(buf), /*timeoutMs=*/32);
         if (n == 0) continue;
-        if (buf[0] != SteamController::REPORT_STATE) continue;
+
+        // Battery status — update DS4 battery level; no further processing needed.
+        if (buf[0] == SteamController::REPORT_BATTERY_STATUS) {
+            if (n >= 3 && slot->vc)
+                slot->vc->SetBatteryState(buf[1], buf[2]);
+            continue;
+        }
+
+        if (!SteamController::IsStateReportId(buf[0])) continue;
 
         if (slot->vc) slot->vc->Update(buf, n, m_backConfig, m_backButtonsEnabled);
         slot->trackpad.Update(buf, n);
+
+        // Trackpad haptics — fire once per new touch/click gesture.
+        {
+            const uint8_t b2 = n > 4 ? buf[4] : 0;
+            const uint8_t b3 = n > 5 ? buf[5] : 0;
+            const bool rt = (b2 & SteamController::BTN_TP_RT)       != 0;
+            const bool lt = (b3 & SteamController::BTN_TP_LT)       != 0;
+            const bool rc = (b2 & SteamController::BTN_TP_RT_CLICK) != 0;
+            const bool lc = (b3 & SteamController::BTN_TP_LT_CLICK) != 0;
+            if (rc && !slot->hapticWasRightClicked)  slot->sc->PulseTrackpadHaptic(false, true);
+            if (lc && !slot->hapticWasLeftClicked)   slot->sc->PulseTrackpadHaptic(true,  true);
+            if (rt && !slot->hapticWasRightTouching && !rc) slot->sc->PulseTrackpadHaptic(false, false);
+            if (lt && !slot->hapticWasLeftTouching  && !lc) slot->sc->PulseTrackpadHaptic(true,  false);
+            slot->hapticWasRightTouching = rt;
+            slot->hapticWasLeftTouching  = lt;
+            slot->hapticWasRightClicked  = rc;
+            slot->hapticWasLeftClicked   = lc;
+        }
 
         // Fire mouse button events for back paddles mapped to LeftMouseButton/RightMouseButton.
         // Uses edge detection so we only send DOWN on press and UP on release.

--- a/src/app/TrackpadMouse.cpp
+++ b/src/app/TrackpadMouse.cpp
@@ -4,8 +4,6 @@
 #include <cstring>
 #include <cstdint>
 
-static constexpr uint8_t BTN_TP_RT_CLICK = 0x40;  // buf[4] bit 6 — hard press
-
 static void SendMouseButton(DWORD flags) {
     INPUT input{};
     input.type       = INPUT_MOUSE;
@@ -51,7 +49,7 @@ void TrackpadMouse::Update(const uint8_t* buf, size_t n) {
         : (b2 & SteamController::BTN_TP_RT)        != 0;
     const bool clicking = m_useLeftTrackpad
         ? (b3 & SteamController::BTN_TP_LT_CLICK)  != 0
-        : (b2 & BTN_TP_RT_CLICK)                    != 0;
+        : (b2 & SteamController::BTN_TP_RT_CLICK)   != 0;
 
     int16_t x = 0, y = 0;
     if (m_useLeftTrackpad) {

--- a/src/app/VirtualController.cpp
+++ b/src/app/VirtualController.cpp
@@ -1,41 +1,31 @@
 #include "VirtualController.h"
 #include "steam/SteamController.h"
-#include <ViGEmClient.h>
-#include <cstdio>
+#include <ViGEm/Client.h>
 #include <algorithm>
-#include <mutex>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <thread>
 #include <utility>
 
-static std::mutex g_notificationMutex;
-static VirtualController* g_notificationSink = nullptr;
+static_assert(sizeof(DS4_REPORT_EX) == 63, "DS4_REPORT_EX must be 63 bytes");
 
-static VOID X360Notification(
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static VOID CALLBACK X360Notification(
     PVIGEM_CLIENT,
     PVIGEM_TARGET,
     UCHAR largeMotor,
     UCHAR smallMotor,
-    UCHAR)
+    UCHAR /*ledNumber*/,
+    LPVOID userData)
 {
-    std::lock_guard<std::mutex> lock(g_notificationMutex);
-    if (g_notificationSink)
-        g_notificationSink->OnRumble(largeMotor, smallMotor);
+    if (userData)
+        static_cast<VirtualController*>(userData)->OnRumble(largeMotor, smallMotor);
 }
-
-static VOID DS4Notification(
-    PVIGEM_CLIENT,
-    PVIGEM_TARGET,
-    UCHAR largeMotor,
-    UCHAR smallMotor,
-    DS4_LIGHTBAR_COLOR)
-{
-    std::lock_guard<std::mutex> lock(g_notificationMutex);
-    if (g_notificationSink)
-        g_notificationSink->OnRumble(largeMotor, smallMotor);
-}
-
-// ---------------------------------------------------------------------------
-// Report translation — 0x45 → XUSB_REPORT
-// ---------------------------------------------------------------------------
 
 static void ApplyBackActionX360(BackButtonAction action, XUSB_REPORT& r) {
     switch (action) {
@@ -62,6 +52,10 @@ static void ApplyBackActionX360(BackButtonAction action, XUSB_REPORT& r) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Report translation — STATE → XUSB_REPORT
+// ---------------------------------------------------------------------------
+
 static XUSB_REPORT TranslateX360(const uint8_t* buf, size_t n) {
     XUSB_REPORT r{};
     if (n < 18) return r;
@@ -70,41 +64,33 @@ static XUSB_REPORT TranslateX360(const uint8_t* buf, size_t n) {
     const uint8_t b1 = buf[3];
     const uint8_t b2 = buf[4];
 
-    // Face buttons
     if (b0 & SteamController::BTN_A) r.wButtons |= XUSB_GAMEPAD_A;
     if (b0 & SteamController::BTN_B) r.wButtons |= XUSB_GAMEPAD_B;
     if (b0 & SteamController::BTN_X) r.wButtons |= XUSB_GAMEPAD_X;
     if (b0 & SteamController::BTN_Y) r.wButtons |= XUSB_GAMEPAD_Y;
 
-    // Bumpers
     if (b2 & SteamController::BTN_LB) r.wButtons |= XUSB_GAMEPAD_LEFT_SHOULDER;
     if (b1 & SteamController::BTN_RB) r.wButtons |= XUSB_GAMEPAD_RIGHT_SHOULDER;
 
-    // Menu / View (Start / Back)
     if (b0 & SteamController::BTN_MENU) r.wButtons |= XUSB_GAMEPAD_START;
     if (b1 & SteamController::BTN_VIEW) r.wButtons |= XUSB_GAMEPAD_BACK;
 
-    // Stick clicks
     if (b1 & SteamController::BTN_LS) r.wButtons |= XUSB_GAMEPAD_LEFT_THUMB;
     if (b0 & SteamController::BTN_RS) r.wButtons |= XUSB_GAMEPAD_RIGHT_THUMB;
 
-    // Steam / Guide button
     if (b2 & SteamController::BTN_STEAM) r.wButtons |= XUSB_GAMEPAD_GUIDE;
 
-    // D-pad
     if (b1 & SteamController::BTN_DPAD_UP) r.wButtons |= XUSB_GAMEPAD_DPAD_UP;
     if (b1 & SteamController::BTN_DPAD_DN) r.wButtons |= XUSB_GAMEPAD_DPAD_DOWN;
     if (b1 & SteamController::BTN_DPAD_LT) r.wButtons |= XUSB_GAMEPAD_DPAD_LEFT;
     if (b1 & SteamController::BTN_DPAD_RT) r.wButtons |= XUSB_GAMEPAD_DPAD_RIGHT;
 
-    // Triggers: 16-bit signed (0x0000–0x7FFF) → 8-bit (0–255)
     int16_t ltRaw, rtRaw;
     memcpy(&ltRaw, buf + 6, 2);
     memcpy(&rtRaw, buf + 8, 2);
     r.bLeftTrigger  = static_cast<uint8_t>(std::clamp<int>(ltRaw >> 7, 0, 255));
     r.bRightTrigger = static_cast<uint8_t>(std::clamp<int>(rtRaw >> 7, 0, 255));
 
-    // Sticks: 16-bit signed, same range as XInput — pass through directly
     memcpy(&r.sThumbLX, buf + 10, 2);
     memcpy(&r.sThumbLY, buf + 12, 2);
     memcpy(&r.sThumbRX, buf + 14, 2);
@@ -114,126 +100,46 @@ static XUSB_REPORT TranslateX360(const uint8_t* buf, size_t n) {
 }
 
 // ---------------------------------------------------------------------------
-// Report translation — 0x45 → DS4_REPORT
+// Report translation — STATE → DS4_REPORT_EX (with gyro, touchpad, battery)
 // ---------------------------------------------------------------------------
 
-// Maps signed 16-bit XInput range to DS4 unsigned byte (0=min, 128=center, 255=max).
 static uint8_t s16ToU8(int16_t v) {
     return static_cast<uint8_t>((static_cast<int32_t>(v) + 32768) >> 8);
 }
 
-static DS4_REPORT TranslateDS4(const uint8_t* buf, size_t n,
-                                const BackButtonConfig& backCfg, bool backMouseEnabled) {
-    DS4_REPORT r{};
-    // Zero-init gives sticks at 0; we set them from actual data below, and
-    // always call DS4_SET_DPAD at the end — so no need for DS4_REPORT_INIT.
-    if (n < 18) {
-        // Return centered sticks and D-pad none as safe default.
-        r.bThumbLX = r.bThumbLY = r.bThumbRX = r.bThumbRY = 0x80;
-        DS4_SET_DPAD(&r, DS4_BUTTON_DPAD_NONE);
-        return r;
-    }
+static int16_t NegI16(int16_t v) {
+    return static_cast<int16_t>((v == -32768) ? 32767 : -v);
+}
 
-    const uint8_t b0 = buf[2];
-    const uint8_t b1 = buf[3];
-    const uint8_t b2 = buf[4];
+// Pack two 12-bit XY values into the 3-byte DS4 touch data encoding.
+static void PackDs4Touch(uint8_t data[3], int x, int y) {
+    data[0] = static_cast<uint8_t>(x & 0xFF);
+    data[1] = static_cast<uint8_t>(((x >> 8) & 0x0F) | ((y & 0x0F) << 4));
+    data[2] = static_cast<uint8_t>((y >> 4) & 0xFF);
+}
 
-    // Face buttons (A→Cross, B→Circle, X→Square, Y→Triangle)
-    if (b0 & SteamController::BTN_A) r.wButtons |= DS4_BUTTON_CROSS;
-    if (b0 & SteamController::BTN_B) r.wButtons |= DS4_BUTTON_CIRCLE;
-    if (b0 & SteamController::BTN_X) r.wButtons |= DS4_BUTTON_SQUARE;
-    if (b0 & SteamController::BTN_Y) r.wButtons |= DS4_BUTTON_TRIANGLE;
+// Map a signed 16-bit SC pad axis to a DS4 touch coordinate (0..maxValue).
+static int NormalizePadAxis(int16_t raw, int maxValue, bool invert) {
+    int v = raw;
+    if (invert) v = (v == -32768) ? 32767 : -v;
+    const int normalized = static_cast<int>(
+        (static_cast<int64_t>(v) + 32768) * maxValue / 65535);
+    return std::clamp(normalized, 0, maxValue);
+}
 
-    // Bumpers
-    if (b2 & SteamController::BTN_LB) r.wButtons |= DS4_BUTTON_SHOULDER_LEFT;
-    if (b1 & SteamController::BTN_RB) r.wButtons |= DS4_BUTTON_SHOULDER_RIGHT;
+// Extract large/small motor from a DS4 output report buffer.
+static bool ParseDs4OutputRumble(const DS4_OUTPUT_BUFFER& output,
+                                  uint8_t& largeMotor, uint8_t& smallMotor) {
+    const uint8_t* b = output.Buffer;
+    if (b[0] == 0x05) { smallMotor = b[3]; largeMotor = b[4]; return true; }
+    if (b[0] == 0x11) { smallMotor = b[6]; largeMotor = b[7]; return true; }
+    return false;
+}
 
-    // Options / Share (Menu→Options, View→Share)
-    if (b0 & SteamController::BTN_MENU) r.wButtons |= DS4_BUTTON_OPTIONS;
-    if (b1 & SteamController::BTN_VIEW) r.wButtons |= DS4_BUTTON_SHARE;
-
-    // Stick clicks
-    if (b1 & SteamController::BTN_LS) r.wButtons |= DS4_BUTTON_THUMB_LEFT;
-    if (b0 & SteamController::BTN_RS) r.wButtons |= DS4_BUTTON_THUMB_RIGHT;
-
-    // PS / Steam button
-    if (b2 & SteamController::BTN_STEAM) r.bSpecial |= DS4_SPECIAL_BUTTON_PS;
-
-    // Right trackpad click → DS4 touchpad button
-    if (b2 & SteamController::BTN_TP_RT) r.bSpecial |= DS4_SPECIAL_BUTTON_TOUCHPAD;
-
-    // D-pad: accumulate all direction sources before computing the HAT.
-    bool dUp = (b1 & SteamController::BTN_DPAD_UP) != 0;
-    bool dDn = (b1 & SteamController::BTN_DPAD_DN) != 0;
-    bool dLt = (b1 & SteamController::BTN_DPAD_LT) != 0;
-    bool dRt = (b1 & SteamController::BTN_DPAD_RT) != 0;
-
-    // Triggers: 16-bit signed (0x0000–0x7FFF) → 8-bit (0–255)
-    int16_t ltRaw, rtRaw;
-    memcpy(&ltRaw, buf + 6, 2);
-    memcpy(&rtRaw, buf + 8, 2);
-    r.bTriggerL = static_cast<uint8_t>(std::clamp<int>(ltRaw >> 7, 0, 255));
-    r.bTriggerR = static_cast<uint8_t>(std::clamp<int>(rtRaw >> 7, 0, 255));
-
-    // Sticks: signed 16-bit → uint8 centered at 0x80.
-    // DS4 Y axis is inverted vs XInput (0 = up, 255 = down).
-    int16_t lx, ly, rx, ry;
-    memcpy(&lx, buf + 10, 2);
-    memcpy(&ly, buf + 12, 2);
-    memcpy(&rx, buf + 14, 2);
-    memcpy(&ry, buf + 16, 2);
-    r.bThumbLX = s16ToU8(lx);
-    r.bThumbLY = static_cast<uint8_t>(255u - s16ToU8(ly));
-    r.bThumbRX = s16ToU8(rx);
-    r.bThumbRY = static_cast<uint8_t>(255u - s16ToU8(ry));
-
-    // Back paddles: apply to report and accumulate D-pad bits.
-    auto applyBack = [&](BackButtonAction action) {
-        switch (action) {
-        case BackButtonAction::A:         r.wButtons |= DS4_BUTTON_CROSS;          break;
-        case BackButtonAction::B:         r.wButtons |= DS4_BUTTON_CIRCLE;         break;
-        case BackButtonAction::X:         r.wButtons |= DS4_BUTTON_SQUARE;         break;
-        case BackButtonAction::Y:         r.wButtons |= DS4_BUTTON_TRIANGLE;       break;
-        case BackButtonAction::LB:        r.wButtons |= DS4_BUTTON_SHOULDER_LEFT;  break;
-        case BackButtonAction::RB:        r.wButtons |= DS4_BUTTON_SHOULDER_RIGHT; break;
-        case BackButtonAction::LT:        r.bTriggerL = 255;                       break;
-        case BackButtonAction::RT:        r.bTriggerR = 255;                       break;
-        case BackButtonAction::DPadUp:    dUp = true;                              break;
-        case BackButtonAction::DPadDown:  dDn = true;                              break;
-        case BackButtonAction::DPadLeft:  dLt = true;                              break;
-        case BackButtonAction::DPadRight: dRt = true;                              break;
-        case BackButtonAction::Menu:      r.wButtons |= DS4_BUTTON_OPTIONS;        break;
-        case BackButtonAction::View:      r.wButtons |= DS4_BUTTON_SHARE;          break;
-        case BackButtonAction::L3:        r.wButtons |= DS4_BUTTON_THUMB_LEFT;     break;
-        case BackButtonAction::R3:        r.wButtons |= DS4_BUTTON_THUMB_RIGHT;    break;
-        default: break;
-        }
-    };
-
-    if (n > 4) {
-        if (!backMouseEnabled && (buf[4] & SteamController::BTN_L4)) applyBack(backCfg.l4);
-        if (buf[4] & SteamController::BTN_L5) applyBack(backCfg.l5);
-    }
-    if (n > 2) {
-        if (!backMouseEnabled && (buf[2] & SteamController::BTN_R4)) applyBack(backCfg.r4);
-    }
-    if (n > 3) {
-        if (buf[3] & SteamController::BTN_R5) applyBack(backCfg.r5);
-    }
-
-    // Resolve accumulated D-pad bits into a HAT value (handles diagonals).
-    DS4_DPAD_DIRECTIONS hat = DS4_BUTTON_DPAD_NONE;
-    if      (dUp && dRt) hat = DS4_BUTTON_DPAD_NORTHEAST;
-    else if (dUp && dLt) hat = DS4_BUTTON_DPAD_NORTHWEST;
-    else if (dDn && dRt) hat = DS4_BUTTON_DPAD_SOUTHEAST;
-    else if (dDn && dLt) hat = DS4_BUTTON_DPAD_SOUTHWEST;
-    else if (dUp)        hat = DS4_BUTTON_DPAD_NORTH;
-    else if (dRt)        hat = DS4_BUTTON_DPAD_EAST;
-    else if (dDn)        hat = DS4_BUTTON_DPAD_SOUTH;
-    else if (dLt)        hat = DS4_BUTTON_DPAD_WEST;
-    DS4_SET_DPAD(&r, hat);
-
-    return r;
+// Set the D-pad HAT bits (lower 4 bits of wButtons) on the EX report.
+// DS4_SET_DPAD macro is not usable here because it expects PDS4_REPORT (the simple struct).
+static void SetDs4DPad(USHORT& wButtons, DS4_DPAD_DIRECTIONS dir) {
+    wButtons = (wButtons & ~static_cast<USHORT>(0xF)) | static_cast<USHORT>(dir);
 }
 
 // ---------------------------------------------------------------------------
@@ -255,9 +161,9 @@ VirtualController::VirtualController(ControllerPlatform platform, RumbleCallback
         return;
     }
 
-    m_target = (platform == ControllerPlatform::Xbox)
-        ? vigem_target_x360_alloc()
-        : vigem_target_ds4_alloc();
+    m_target = (platform == ControllerPlatform::PlayStation)
+        ? vigem_target_ds4_alloc()
+        : vigem_target_x360_alloc();
     if (!m_target) { printf("[ViGEm] target alloc failed\n"); return; }
 
     err = vigem_target_add(static_cast<PVIGEM_CLIENT>(m_client),
@@ -269,45 +175,38 @@ VirtualController::VirtualController(ControllerPlatform platform, RumbleCallback
         return;
     }
 
-    if (platform == ControllerPlatform::Xbox) {
+    if (platform == ControllerPlatform::PlayStation) {
+        printf("[ViGEm] Virtual DualShock 4 controller connected\n");
+        StartDs4OutputThread();
+    } else {
         printf("[ViGEm] Virtual Xbox 360 controller connected\n");
         err = vigem_target_x360_register_notification(
             static_cast<PVIGEM_CLIENT>(m_client),
             static_cast<PVIGEM_TARGET>(m_target),
-            X360Notification);
-    } else {
-        printf("[ViGEm] Virtual DualShock 4 controller connected\n");
-        err = vigem_target_ds4_register_notification(
-            static_cast<PVIGEM_CLIENT>(m_client),
-            static_cast<PVIGEM_TARGET>(m_target),
-            DS4Notification);
-    }
-
-    if (!VIGEM_SUCCESS(err))
-        printf("[ViGEm] notification registration failed: 0x%08X\n", err);
-    else {
-        std::lock_guard<std::mutex> lock(g_notificationMutex);
-        g_notificationSink = this;
+            X360Notification,
+            this);
+        if (!VIGEM_SUCCESS(err)) {
+            printf("[ViGEm] notification registration failed: 0x%08X\n", err);
+            vigem_target_remove(static_cast<PVIGEM_CLIENT>(m_client),
+                                static_cast<PVIGEM_TARGET>(m_target));
+            vigem_target_free(static_cast<PVIGEM_TARGET>(m_target));
+            m_target = nullptr;
+            return;
+        }
     }
 
     m_valid = true;
 }
 
 VirtualController::~VirtualController() {
-    if (m_target) {
-        if (m_platform == ControllerPlatform::Xbox)
-            vigem_target_x360_unregister_notification(static_cast<PVIGEM_TARGET>(m_target));
-        else
-            vigem_target_ds4_unregister_notification(static_cast<PVIGEM_TARGET>(m_target));
-        std::lock_guard<std::mutex> lock(g_notificationMutex);
-        if (g_notificationSink == this)
-            g_notificationSink = nullptr;
-    }
+    StopDs4OutputThread();
 
-    if (m_client && m_target) {
+    if (m_target && m_platform == ControllerPlatform::Xbox)
+        vigem_target_x360_unregister_notification(static_cast<PVIGEM_TARGET>(m_target));
+
+    if (m_client && m_target)
         vigem_target_remove(static_cast<PVIGEM_CLIENT>(m_client),
                             static_cast<PVIGEM_TARGET>(m_target));
-    }
     if (m_target) vigem_target_free(static_cast<PVIGEM_TARGET>(m_target));
     if (m_client) {
         vigem_disconnect(static_cast<PVIGEM_CLIENT>(m_client));
@@ -315,10 +214,237 @@ VirtualController::~VirtualController() {
     }
 }
 
-void VirtualController::Update(const uint8_t* buf, size_t n, const BackButtonConfig& backCfg, bool backMouseEnabled) {
+void VirtualController::StartDs4OutputThread() {
+    if (m_ds4OutputRunning.exchange(true)) return;
+    m_ds4OutputThread = std::thread(&VirtualController::Ds4OutputLoop, this);
+}
+
+void VirtualController::StopDs4OutputThread() {
+    m_ds4OutputRunning = false;
+    if (m_ds4OutputThread.joinable())
+        m_ds4OutputThread.join();
+}
+
+void VirtualController::Ds4OutputLoop() {
+    while (m_ds4OutputRunning && m_client && m_target) {
+        DS4_OUTPUT_BUFFER output{};
+        VIGEM_ERROR err = vigem_target_ds4_await_output_report_timeout(
+            static_cast<PVIGEM_CLIENT>(m_client),
+            static_cast<PVIGEM_TARGET>(m_target),
+            100,
+            &output);
+
+        if (!m_ds4OutputRunning) break;
+        if (err == VIGEM_ERROR_TIMED_OUT) continue;
+        if (!VIGEM_SUCCESS(err)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            continue;
+        }
+
+        uint8_t largeMotor = 0, smallMotor = 0;
+        if (ParseDs4OutputRumble(output, largeMotor, smallMotor))
+            OnRumble(largeMotor, smallMotor);
+    }
+}
+
+void VirtualController::SetBatteryState(uint8_t levelPercent, uint8_t chargeState) {
+    if (chargeState == SteamController::CHARGE_STATE_CHARGING_DONE || levelPercent >= 95) {
+        m_ds4BatteryLevel   = 0x0B;
+        m_ds4BatterySpecial = 0x0B;
+        return;
+    }
+    const int level = std::clamp((static_cast<int>(levelPercent) * 10 + 50) / 100, 0, 10);
+    m_ds4BatteryLevel   = static_cast<uint8_t>(level);
+    m_ds4BatterySpecial = static_cast<uint8_t>(0x10 | level);
+}
+
+void VirtualController::SetTrackpadMouseClaim(bool enabled, bool useLeftTrackpad) {
+    m_trackpadMouseEnabled    = enabled;
+    m_useLeftTrackpadForMouse = useLeftTrackpad;
+}
+
+void VirtualController::Update(const uint8_t* buf, size_t n,
+                               const BackButtonConfig& backCfg, bool backMouseEnabled) {
     if (!m_valid) return;
 
-    if (m_platform == ControllerPlatform::Xbox) {
+    if (m_platform == ControllerPlatform::PlayStation) {
+        // Suppress a pad from the DS4 touchpad report when it is claimed for mouse use.
+        const bool suppressRight = m_trackpadMouseEnabled && !m_useLeftTrackpadForMouse;
+        const bool suppressLeft  = m_trackpadMouseEnabled &&  m_useLeftTrackpadForMouse;
+
+        DS4_REPORT_EX ex{};
+        auto& r = ex.Report;
+
+        if (n < 18) {
+            r.bThumbLX = r.bThumbLY = r.bThumbRX = r.bThumbRY = 0x80;
+            SetDs4DPad(r.wButtons, DS4_BUTTON_DPAD_NONE);
+        } else {
+            const uint8_t b0 = buf[2];
+            const uint8_t b1 = buf[3];
+            const uint8_t b2 = buf[4];
+            const uint8_t b3 = n > 5 ? buf[5] : 0;
+
+            if (b0 & SteamController::BTN_A) r.wButtons |= DS4_BUTTON_CROSS;
+            if (b0 & SteamController::BTN_B) r.wButtons |= DS4_BUTTON_CIRCLE;
+            if (b0 & SteamController::BTN_X) r.wButtons |= DS4_BUTTON_SQUARE;
+            if (b0 & SteamController::BTN_Y) r.wButtons |= DS4_BUTTON_TRIANGLE;
+            if (b2 & SteamController::BTN_LB) r.wButtons |= DS4_BUTTON_SHOULDER_LEFT;
+            if (b1 & SteamController::BTN_RB) r.wButtons |= DS4_BUTTON_SHOULDER_RIGHT;
+            if (b0 & SteamController::BTN_MENU) r.wButtons |= DS4_BUTTON_OPTIONS;
+            if (b1 & SteamController::BTN_VIEW) r.wButtons |= DS4_BUTTON_SHARE;
+            if (b1 & SteamController::BTN_LS) r.wButtons |= DS4_BUTTON_THUMB_LEFT;
+            if (b0 & SteamController::BTN_RS) r.wButtons |= DS4_BUTTON_THUMB_RIGHT;
+            if (b2 & SteamController::BTN_STEAM) r.bSpecial |= DS4_SPECIAL_BUTTON_PS;
+
+            bool dUp = (b1 & SteamController::BTN_DPAD_UP) != 0;
+            bool dDn = (b1 & SteamController::BTN_DPAD_DN) != 0;
+            bool dLt = (b1 & SteamController::BTN_DPAD_LT) != 0;
+            bool dRt = (b1 & SteamController::BTN_DPAD_RT) != 0;
+
+            int16_t ltRaw, rtRaw;
+            memcpy(&ltRaw, buf + 6, 2);
+            memcpy(&rtRaw, buf + 8, 2);
+            r.bTriggerL = static_cast<uint8_t>(std::clamp<int>(ltRaw >> 7, 0, 255));
+            r.bTriggerR = static_cast<uint8_t>(std::clamp<int>(rtRaw >> 7, 0, 255));
+            if (r.bTriggerL > 0) r.wButtons |= DS4_BUTTON_TRIGGER_LEFT;
+            if (r.bTriggerR > 0) r.wButtons |= DS4_BUTTON_TRIGGER_RIGHT;
+
+            int16_t lx, ly, rx, ry;
+            memcpy(&lx, buf + 10, 2);
+            memcpy(&ly, buf + 12, 2);
+            memcpy(&rx, buf + 14, 2);
+            memcpy(&ry, buf + 16, 2);
+            r.bThumbLX = s16ToU8(lx);
+            r.bThumbLY = static_cast<uint8_t>(255u - s16ToU8(ly));
+            r.bThumbRX = s16ToU8(rx);
+            r.bThumbRY = static_cast<uint8_t>(255u - s16ToU8(ry));
+
+            // Back paddles
+            auto applyBack = [&](BackButtonAction action) {
+                switch (action) {
+                case BackButtonAction::A:         r.wButtons |= DS4_BUTTON_CROSS;          break;
+                case BackButtonAction::B:         r.wButtons |= DS4_BUTTON_CIRCLE;         break;
+                case BackButtonAction::X:         r.wButtons |= DS4_BUTTON_SQUARE;         break;
+                case BackButtonAction::Y:         r.wButtons |= DS4_BUTTON_TRIANGLE;       break;
+                case BackButtonAction::LB:        r.wButtons |= DS4_BUTTON_SHOULDER_LEFT;  break;
+                case BackButtonAction::RB:        r.wButtons |= DS4_BUTTON_SHOULDER_RIGHT; break;
+                case BackButtonAction::LT:        r.bTriggerL = 255;                       break;
+                case BackButtonAction::RT:        r.bTriggerR = 255;                       break;
+                case BackButtonAction::DPadUp:    dUp = true;                              break;
+                case BackButtonAction::DPadDown:  dDn = true;                              break;
+                case BackButtonAction::DPadLeft:  dLt = true;                              break;
+                case BackButtonAction::DPadRight: dRt = true;                              break;
+                case BackButtonAction::Menu:      r.wButtons |= DS4_BUTTON_OPTIONS;        break;
+                case BackButtonAction::View:      r.wButtons |= DS4_BUTTON_SHARE;          break;
+                case BackButtonAction::L3:        r.wButtons |= DS4_BUTTON_THUMB_LEFT;     break;
+                case BackButtonAction::R3:        r.wButtons |= DS4_BUTTON_THUMB_RIGHT;    break;
+                default: break;
+                }
+            };
+            if (n > 4) {
+                if (!backMouseEnabled && (buf[4] & SteamController::BTN_L4)) applyBack(backCfg.l4);
+                if (buf[4] & SteamController::BTN_L5) applyBack(backCfg.l5);
+            }
+            if (n > 2) {
+                if (!backMouseEnabled && (buf[2] & SteamController::BTN_R4)) applyBack(backCfg.r4);
+            }
+            if (n > 3) {
+                if (buf[3] & SteamController::BTN_R5) applyBack(backCfg.r5);
+            }
+
+            DS4_DPAD_DIRECTIONS hat = DS4_BUTTON_DPAD_NONE;
+            if      (dUp && dRt) hat = DS4_BUTTON_DPAD_NORTHEAST;
+            else if (dUp && dLt) hat = DS4_BUTTON_DPAD_NORTHWEST;
+            else if (dDn && dRt) hat = DS4_BUTTON_DPAD_SOUTHEAST;
+            else if (dDn && dLt) hat = DS4_BUTTON_DPAD_SOUTHWEST;
+            else if (dUp)        hat = DS4_BUTTON_DPAD_NORTH;
+            else if (dRt)        hat = DS4_BUTTON_DPAD_EAST;
+            else if (dDn)        hat = DS4_BUTTON_DPAD_SOUTH;
+            else if (dLt)        hat = DS4_BUTTON_DPAD_WEST;
+            SetDs4DPad(r.wButtons, hat);
+
+            // Touchpad — right SC pad → DS4 contact 1, left SC pad → DS4 contact 2
+            const bool rawRightTouching = (b2 & SteamController::BTN_TP_RT)       != 0;
+            const bool rawLeftTouching  = (b3 & SteamController::BTN_TP_LT)       != 0;
+            const bool rawRightClick    = (b2 & SteamController::BTN_TP_RT_CLICK) != 0;
+            const bool rawLeftClick     = (b3 & SteamController::BTN_TP_LT_CLICK) != 0;
+
+            const bool rightTouching = rawRightTouching && !suppressRight;
+            const bool leftTouching  = rawLeftTouching  && !suppressLeft;
+
+            if ((rawRightClick && !suppressRight) || (rawLeftClick && !suppressLeft))
+                r.bSpecial |= DS4_SPECIAL_BUTTON_TOUCHPAD;
+
+            if (rightTouching && !m_wasRightTouching)
+                m_rightTracking = static_cast<uint8_t>((m_rightTracking + 1) & 0x7F);
+            if (leftTouching && !m_wasLeftTouching)
+                m_leftTracking  = static_cast<uint8_t>((m_leftTracking  + 1) & 0x7F);
+            m_wasRightTouching = rightTouching;
+            m_wasLeftTouching  = leftTouching;
+
+            int16_t rPadX = 0, rPadY = 0, lPadX = 0, lPadY = 0;
+            if (n >= 28) {
+                memcpy(&lPadX, buf + 18, 2);
+                memcpy(&lPadY, buf + 20, 2);
+                memcpy(&rPadX, buf + 24, 2);
+                memcpy(&rPadY, buf + 26, 2);
+            }
+
+            DS4_TOUCH& touch = r.sCurrentTouch;
+            touch.bPacketCounter    = ++m_touchPacketCounter;
+            touch.bIsUpTrackingNum1 = static_cast<uint8_t>(m_rightTracking | (rightTouching ? 0x00 : 0x80));
+            touch.bIsUpTrackingNum2 = static_cast<uint8_t>(m_leftTracking  | (leftTouching  ? 0x00 : 0x80));
+            PackDs4Touch(touch.bTouchData1,
+                         rightTouching ? NormalizePadAxis(rPadX, 1919, false) : 0,
+                         rightTouching ? NormalizePadAxis(rPadY, 942,  true)  : 0);
+            PackDs4Touch(touch.bTouchData2,
+                         leftTouching  ? NormalizePadAxis(lPadX, 1919, false) : 0,
+                         leftTouching  ? NormalizePadAxis(lPadY, 942,  true)  : 0);
+            r.bTouchPacketsN    = 1;
+            r.sPreviousTouch[0] = touch;
+            r.sPreviousTouch[1] = touch;
+
+            // IMU — only present when SETTING_IMU_MODE = IMU_MODE_RAW_ACCEL_GYRO (report ≥ 46 bytes)
+            if (n >= 46) {
+                uint32_t imuTs = 0;
+                int16_t accelX = 0, accelY = 0, accelZ = 0;
+                int16_t gyroX  = 0, gyroY  = 0, gyroZ  = 0;
+                memcpy(&imuTs,  buf + 30, 4);
+                memcpy(&accelX, buf + 34, 2);
+                memcpy(&accelY, buf + 36, 2);
+                memcpy(&accelZ, buf + 38, 2);
+                memcpy(&gyroX,  buf + 40, 2);
+                memcpy(&gyroY,  buf + 42, 2);
+                memcpy(&gyroZ,  buf + 44, 2);
+
+                if (!m_hasLastImuTimestamp || imuTs != m_lastImuTimestamp) {
+                    const uint32_t delta = m_hasLastImuTimestamp ? (imuTs - m_lastImuTimestamp) : 0;
+                    m_ds4Timestamp = static_cast<uint16_t>(
+                        m_ds4Timestamp + static_cast<uint16_t>(std::max<uint32_t>(1, delta / 16)));
+                    m_lastImuTimestamp    = imuTs;
+                    m_hasLastImuTimestamp = true;
+                }
+
+                // SC → DS4 axis remapping: SC Y↔Z swapped, Y negated.
+                r.wGyroX  = gyroX;
+                r.wGyroY  = gyroZ;
+                r.wGyroZ  = NegI16(gyroY);
+                r.wAccelX = accelX;
+                r.wAccelY = accelZ;
+                r.wAccelZ = NegI16(accelY);
+            } else {
+                ++m_ds4Timestamp;
+            }
+            r.wTimestamp = m_ds4Timestamp;
+
+            r.bBatteryLvl        = m_ds4BatteryLevel;
+            r.bBatteryLvlSpecial = m_ds4BatterySpecial;
+        }
+
+        vigem_target_ds4_update_ex(static_cast<PVIGEM_CLIENT>(m_client),
+                                   static_cast<PVIGEM_TARGET>(m_target),
+                                   ex);
+    } else {
         XUSB_REPORT report = TranslateX360(buf, n);
 
         if (n > 4) {
@@ -335,11 +461,6 @@ void VirtualController::Update(const uint8_t* buf, size_t n, const BackButtonCon
         vigem_target_x360_update(static_cast<PVIGEM_CLIENT>(m_client),
                                  static_cast<PVIGEM_TARGET>(m_target),
                                  report);
-    } else {
-        DS4_REPORT report = TranslateDS4(buf, n, backCfg, backMouseEnabled);
-        vigem_target_ds4_update(static_cast<PVIGEM_CLIENT>(m_client),
-                                static_cast<PVIGEM_TARGET>(m_target),
-                                report);
     }
 }
 

--- a/src/app/VirtualController.cpp
+++ b/src/app/VirtualController.cpp
@@ -441,9 +441,12 @@ void VirtualController::Update(const uint8_t* buf, size_t n,
             r.bBatteryLvlSpecial = m_ds4BatterySpecial;
         }
 
-        vigem_target_ds4_update_ex(static_cast<PVIGEM_CLIENT>(m_client),
-                                   static_cast<PVIGEM_TARGET>(m_target),
-                                   ex);
+        VIGEM_ERROR exErr = vigem_target_ds4_update_ex(
+            static_cast<PVIGEM_CLIENT>(m_client),
+            static_cast<PVIGEM_TARGET>(m_target),
+            ex);
+        if (!VIGEM_SUCCESS(exErr))
+            printf("[ViGEm] ds4_update_ex failed: 0x%08X (bus driver may need update)\n", exErr);
     } else {
         XUSB_REPORT report = TranslateX360(buf, n);
 

--- a/src/app/VirtualController.h
+++ b/src/app/VirtualController.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
+#include <atomic>
 #include <functional>
+#include <thread>
 #include "BackButtonConfig.h"
 #include "ControllerPlatform.h"
 
@@ -14,17 +16,50 @@ public:
     VirtualController(const VirtualController&) = delete;
     VirtualController& operator=(const VirtualController&) = delete;
 
-    bool IsValid()          const { return m_valid; }
-    bool IsDriverMissing()  const { return m_driverMissing; }
+    bool IsValid()        const { return m_valid; }
+    bool IsDriverMissing() const { return m_driverMissing; }
 
     void Update(const uint8_t* buf, size_t n, const BackButtonConfig& backCfg, bool backMouseEnabled);
     void OnRumble(uint8_t largeMotor, uint8_t smallMotor);
 
+    // DS4-only: update battery level shown in the DS4 report.
+    void SetBatteryState(uint8_t levelPercent, uint8_t chargeState);
+
+    // Tell VirtualController which (if any) trackpad is claimed for mouse use,
+    // so that pad's touch data is excluded from the DS4 touchpad report.
+    void SetTrackpadMouseClaim(bool enabled, bool useLeftTrackpad);
+
 private:
+    void StartDs4OutputThread();
+    void StopDs4OutputThread();
+    void Ds4OutputLoop();
+
     ControllerPlatform m_platform;
-    void* m_client        = nullptr;
-    void* m_target        = nullptr;
+    void*  m_client       = nullptr;
+    void*  m_target       = nullptr;
     RumbleCallback m_rumbleCallback;
-    bool  m_valid         = false;
-    bool  m_driverMissing = false;
+    bool   m_valid        = false;
+    bool   m_driverMissing = false;
+
+    // DS4 touchpad tracking
+    bool     m_trackpadMouseEnabled    = false;
+    bool     m_useLeftTrackpadForMouse = false;
+    uint8_t  m_touchPacketCounter      = 0;
+    uint8_t  m_rightTracking           = 0;
+    uint8_t  m_leftTracking            = 0;
+    bool     m_wasRightTouching        = false;
+    bool     m_wasLeftTouching         = false;
+
+    // DS4 IMU timestamp tracking
+    uint16_t m_ds4Timestamp        = 0;
+    uint32_t m_lastImuTimestamp    = 0;
+    bool     m_hasLastImuTimestamp = false;
+
+    // DS4 battery
+    uint8_t m_ds4BatteryLevel   = 0x0B;  // full / unknown
+    uint8_t m_ds4BatterySpecial = 0x1B;
+
+    // DS4 output thread (polls for rumble/lightbar output reports)
+    std::atomic<bool> m_ds4OutputRunning{false};
+    std::thread       m_ds4OutputThread;
 };

--- a/src/steam/SteamController.cpp
+++ b/src/steam/SteamController.cpp
@@ -1,21 +1,12 @@
 #include "SteamController.h"
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <mutex>
 
 // ---------------------------------------------------------------------------
 // Internal helper: build a 64-byte feature report command buffer.
-//
-// The 2026 Steam Controller routes firmware commands through Feature Report
-// 0x01 (same channel the original SC used, now with an explicit report ID).
-//
-// Buffer layout:
-//   [0] FEATURE_REPORT_CMD (0x01)  — HID feature report ID
-//   [1] cmd                         — command byte (0x81, 0x87, etc.)
-//   [2] payloadSize                 — number of payload bytes that follow
-//   [3..3+payloadSize-1] payload    — command arguments
-//   [rest] zeros
 // ---------------------------------------------------------------------------
 
 static void BuildCmd(uint8_t (&buf)[64], uint8_t cmd,
@@ -27,6 +18,38 @@ static void BuildCmd(uint8_t (&buf)[64], uint8_t cmd,
     if (payload && payloadSize)
         std::memcpy(buf + 3, payload, payloadSize);
 }
+
+static void WriteU16LE(uint8_t* p, uint16_t v) {
+    std::memcpy(p, &v, sizeof(v));
+}
+
+// ---------------------------------------------------------------------------
+// Haptic tuning helpers
+// ---------------------------------------------------------------------------
+
+static double ClampUnit(double v) { return std::clamp(v, 0.0, 1.0); }
+
+static double MotorByteToUnit(uint8_t value) {
+    static constexpr double kDeadzone = 6.0;
+    if (value <= kDeadzone) return 0.0;
+    return (static_cast<double>(value) - kDeadzone) / (255.0 - kDeadzone);
+}
+
+static uint16_t UnitToHapticSpeed(double value, uint16_t minimumSpeed) {
+    value = ClampUnit(value);
+    if (value <= 0.0) return 0;
+    const double curved = std::pow(value, 0.68);
+    const double speed  = static_cast<double>(minimumSpeed)
+                        + curved * static_cast<double>(0xFFFFu - minimumSpeed);
+    return static_cast<uint16_t>(std::clamp<int>(static_cast<int>(std::lround(speed)), 0, 0xFFFF));
+}
+
+static constexpr uint8_t  HAPTIC_COMMAND_TICK  = 1;
+static constexpr uint8_t  HAPTIC_COMMAND_CLICK = 2;
+static constexpr uint16_t TRACKPAD_CLICK_PULSE_US       = 5000;
+static constexpr int8_t   TRACKPAD_TOUCH_GAIN_DB        = -45;
+static constexpr int8_t   TRACKPAD_CLICK_COMMAND_GAIN_DB = 9;
+static constexpr int16_t  TRACKPAD_CLICK_PULSE_GAIN_DB  = 40;
 
 // ---------------------------------------------------------------------------
 // Open / Close
@@ -41,7 +64,7 @@ std::vector<std::wstring> SteamController::EnumerateAll() {
             if (!dev.Open(path)) continue;
             uint8_t buf[64];
             size_t n = dev.ReadInputReport(buf, sizeof(buf), /*timeoutMs=*/500);
-            if (n > 0 && buf[0] == REPORT_STATE)
+            if (n > 0 && IsStateReportId(buf[0]))
                 result.push_back(path);
             else if (n > 0)
                 printf("Unexpected report ID 0x%02X on PID=%04X — skipping.\n", buf[0], pid);
@@ -69,6 +92,8 @@ bool SteamController::Open(const std::wstring& path) {
 void SteamController::Close() {
     if (m_running.exchange(false) && m_heartbeat.joinable())
         m_heartbeat.join();
+    ClearTrackpadHaptics();
+    SetRumble(0, 0);
     m_device.Close();
 }
 
@@ -79,25 +104,33 @@ void SteamController::Close() {
 bool SteamController::DisableLizardMode() {
     uint8_t buf[64];
 
-    // Step 1: CLEAR_DIGITAL_MAPPINGS — kills keyboard/mouse button emulation.
     BuildCmd(buf, CMD_CLEAR_DIGITAL_MAPPINGS);
     {
-        std::lock_guard<std::mutex> lock(m_commandMutex);
+        std::lock_guard<std::mutex> lock(m_writeMutex);
         if (!m_device.SendFeatureReport(buf, sizeof(buf))) {
             printf("Failed to send CLEAR_DIGITAL_MAPPINGS.\n");
             return false;
         }
     }
 
-    // Step 2: SET_SETTINGS — set both trackpads to TRACKPAD_NONE.
-    // Payload: pairs of [setting_id, val_lo, val_hi].
+    // Keep IMU disabled until a virtual output mode that needs it explicitly enables it.
+    const uint8_t imuOff[] = { SETTING_IMU_MODE, 0x00, 0x00 };
+    BuildCmd(buf, CMD_SET_SETTINGS, imuOff, sizeof(imuOff));
+    {
+        std::lock_guard<std::mutex> lock(m_writeMutex);
+        if (!m_device.SendFeatureReport(buf, sizeof(buf))) {
+            printf("Failed to disable IMU mode.\n");
+            return false;
+        }
+    }
+
     const uint8_t settingsPayload[] = {
         SETTING_LEFT_TRACKPAD_MODE,  0x00, 0x00,
         SETTING_RIGHT_TRACKPAD_MODE, 0x00, 0x00,
     };
     BuildCmd(buf, CMD_SET_SETTINGS, settingsPayload, sizeof(settingsPayload));
     {
-        std::lock_guard<std::mutex> lock(m_commandMutex);
+        std::lock_guard<std::mutex> lock(m_writeMutex);
         if (!m_device.SendFeatureReport(buf, sizeof(buf))) {
             printf("Failed to send SET_SETTINGS_VALUES.\n");
             return false;
@@ -114,11 +147,13 @@ bool SteamController::EnableLizardMode() {
     if (m_running.exchange(false) && m_heartbeat.joinable())
         m_heartbeat.join();
 
+    ClearTrackpadHaptics();
     SetRumble(0, 0);
+    SetImuEnabled(false);
 
     uint8_t buf[64];
     BuildCmd(buf, CMD_SET_DEFAULT_MAPPINGS);
-    std::lock_guard<std::mutex> lock(m_commandMutex);
+    std::lock_guard<std::mutex> lock(m_writeMutex);
     return m_device.SendFeatureReport(buf, sizeof(buf));
 }
 
@@ -130,36 +165,167 @@ size_t SteamController::ReadReport(uint8_t* buffer, size_t size, uint32_t timeou
     return m_device.ReadInputReport(buffer, size, timeoutMs);
 }
 
-bool SteamController::SetRumble(uint16_t leftSpeed, uint16_t rightSpeed) {
-    if (!m_device.IsOpen()) return false;
+// ---------------------------------------------------------------------------
+// IMU
+// ---------------------------------------------------------------------------
 
-    m_rumbleLeft.store(leftSpeed);
-    m_rumbleRight.store(rightSpeed);
-    return SendRumbleOutput(leftSpeed, rightSpeed);
-}
-
-bool SteamController::SendRumbleOutput(uint16_t leftSpeed, uint16_t rightSpeed) {
-    const uint16_t intensity = 0;
-    const uint8_t report[] = {
-        OUT_REPORT_HAPTIC_RUMBLE,
-        0x00,
-        static_cast<uint8_t>(intensity & 0xFF),
-        static_cast<uint8_t>(intensity >> 8),
-        static_cast<uint8_t>(leftSpeed & 0xFF),
-        static_cast<uint8_t>(leftSpeed >> 8),
-        0x00,
-        static_cast<uint8_t>(rightSpeed & 0xFF),
-        static_cast<uint8_t>(rightSpeed >> 8),
-        0x00,
+bool SteamController::SetImuEnabled(bool enabled) {
+    const uint16_t value = enabled ? IMU_MODE_RAW_ACCEL_GYRO : IMU_MODE_OFF;
+    const uint8_t payload[] = {
+        SETTING_IMU_MODE,
+        static_cast<uint8_t>(value & 0xFF),
+        static_cast<uint8_t>((value >> 8) & 0xFF),
     };
-
-    std::lock_guard<std::mutex> lock(m_commandMutex);
-    return m_device.WriteOutputReport(report, sizeof(report));
+    uint8_t buf[64];
+    BuildCmd(buf, CMD_SET_SETTINGS, payload, sizeof(payload));
+    std::lock_guard<std::mutex> lock(m_writeMutex);
+    if (!m_device.SendFeatureReport(buf, sizeof(buf))) {
+        printf("Failed to %s IMU mode.\n", enabled ? "enable" : "disable");
+        return false;
+    }
+    return true;
 }
-
 
 // ---------------------------------------------------------------------------
-// Heartbeat
+// Rumble — enhanced haptic model
+//
+// Both XInput large/small motor channels map to the same physical layout on
+// the Steam Controller as on real Xbox/DS4 hardware: large (low-freq) lives
+// in the left grip, small (high-freq) in the right grip.  We cross-mix the
+// two channels across both haptic actuators and add a short "attack boost" on
+// rising edges to replicate the punch of ERM motors starting from rest.
+// ---------------------------------------------------------------------------
+
+void SteamController::SetRumble(uint8_t largeMotor, uint8_t smallMotor) {
+    const double low  = MotorByteToUnit(largeMotor);
+    const double high = MotorByteToUnit(smallMotor);
+
+    const double leftDemand  = ClampUnit(low * 1.00 + high * 0.30);
+    const double rightDemand = ClampUnit(low * 0.78 + high * 0.88);
+    const uint16_t baseLeft  = UnitToHapticSpeed(leftDemand,  0x1200);
+    const uint16_t baseRight = UnitToHapticSpeed(rightDemand, 0x1200);
+
+    const auto now = std::chrono::steady_clock::now();
+    RumbleFrame frame{};
+    {
+        std::lock_guard<std::mutex> lock(m_rumbleMutex);
+
+        const int largeRise = m_hasRumbleState
+            ? static_cast<int>(largeMotor) - static_cast<int>(m_lastLargeMotor) : largeMotor;
+        const int smallRise = m_hasRumbleState
+            ? static_cast<int>(smallMotor) - static_cast<int>(m_lastSmallMotor) : smallMotor;
+
+        m_lastLargeMotor  = largeMotor;
+        m_lastSmallMotor  = smallMotor;
+        m_hasRumbleState  = true;
+        m_rumbleBaseLeft  = baseLeft;
+        m_rumbleBaseRight = baseRight;
+
+        if (baseLeft == 0 && baseRight == 0) {
+            m_rumbleBoostLeft  = 0;
+            m_rumbleBoostRight = 0;
+            m_rumbleBoostUntil = {};
+        } else {
+            const double largePunch = (largeRise > 0 ? largeRise : 0) / 255.0 * 0.55;
+            const double smallPunch = (smallRise > 0 ? smallRise : 0) / 255.0 * 0.38;
+            const double punch = largePunch > smallPunch ? largePunch : smallPunch;
+
+            if (punch >= 0.08) {
+                const double boostL = ClampUnit(leftDemand  + punch * 0.70 + low  * 0.08);
+                const double boostR = ClampUnit(rightDemand + punch * 0.62 + high * 0.10);
+                m_rumbleBoostLeft  = UnitToHapticSpeed(boostL, 0x2200);
+                m_rumbleBoostRight = UnitToHapticSpeed(boostR, 0x2200);
+                m_rumbleBoostUntil = now + std::chrono::milliseconds(55 + (largeMotor >= 180 ? 25 : 0));
+            }
+        }
+
+        m_lastRumbleSent = now;
+        frame = CurrentRumbleFrameLocked(now);
+    }
+
+    SendRumbleOutput(frame.left, frame.right);
+}
+
+SteamController::RumbleFrame SteamController::CurrentRumbleFrameLocked(
+    std::chrono::steady_clock::time_point now) const
+{
+    RumbleFrame frame{m_rumbleBaseLeft, m_rumbleBaseRight};
+    if (m_rumbleBoostUntil > now) {
+        if (m_rumbleBoostLeft  > frame.left)  frame.left  = m_rumbleBoostLeft;
+        if (m_rumbleBoostRight > frame.right) frame.right = m_rumbleBoostRight;
+    }
+    return frame;
+}
+
+// ---------------------------------------------------------------------------
+// Trackpad haptics
+// ---------------------------------------------------------------------------
+
+void SteamController::PulseTrackpadHaptic(bool left, bool strongClick) {
+    const uint8_t side    = left ? 0x01 : 0x02;
+    const uint8_t command = strongClick ? HAPTIC_COMMAND_CLICK : HAPTIC_COMMAND_TICK;
+    const int8_t  gainDb  = strongClick ? TRACKPAD_CLICK_COMMAND_GAIN_DB : TRACKPAD_TOUCH_GAIN_DB;
+    SendTrackpadCommandOutput(side, command, gainDb);
+    if (strongClick)
+        SendTrackpadPulseOutput(side, TRACKPAD_CLICK_PULSE_US, 0, 1, TRACKPAD_CLICK_PULSE_GAIN_DB);
+}
+
+void SteamController::ClearTrackpadHaptics() {
+    // Pulse/command reports are one-shots — no persistent state to cancel.
+    // Kept as a lifecycle hook for clean teardown.
+}
+
+// ---------------------------------------------------------------------------
+// Low-level output
+// ---------------------------------------------------------------------------
+
+bool SteamController::SendRumbleOutput(uint16_t leftSpeed, uint16_t rightSpeed) {
+    if (!m_device.IsOpen()) return false;
+
+    uint8_t buf[10] = {};
+    buf[0] = OUT_HAPTIC_RUMBLE;
+    buf[1] = 0x00;
+    WriteU16LE(buf + 2, 0x0000);   // intensity (unused field)
+    WriteU16LE(buf + 4, leftSpeed);
+    buf[6] = 0x00;                 // left gain
+    WriteU16LE(buf + 7, rightSpeed);
+    buf[9] = 0x00;                 // right gain
+
+    std::lock_guard<std::mutex> lock(m_writeMutex);
+    return m_device.WriteOutputReport(buf, sizeof(buf));
+}
+
+bool SteamController::SendTrackpadPulseOutput(uint8_t side, uint16_t onUs, uint16_t offUs,
+                                               uint16_t repeatCount, int16_t gainDb) {
+    if (!m_device.IsOpen()) return false;
+
+    uint8_t buf[10] = {};
+    buf[0] = OUT_HAPTIC_PULSE;
+    buf[1] = side;
+    WriteU16LE(buf + 2, onUs);
+    WriteU16LE(buf + 4, offUs);
+    WriteU16LE(buf + 6, repeatCount);
+    WriteU16LE(buf + 8, static_cast<uint16_t>(gainDb));
+
+    std::lock_guard<std::mutex> lock(m_writeMutex);
+    return m_device.WriteOutputReport(buf, sizeof(buf));
+}
+
+bool SteamController::SendTrackpadCommandOutput(uint8_t side, uint8_t command, int8_t gainDb) {
+    if (!m_device.IsOpen()) return false;
+
+    uint8_t buf[4] = {};
+    buf[0] = OUT_HAPTIC_COMMAND;
+    buf[1] = side;
+    buf[2] = command;
+    buf[3] = static_cast<uint8_t>(gainDb);
+
+    std::lock_guard<std::mutex> lock(m_writeMutex);
+    return m_device.WriteOutputReport(buf, sizeof(buf));
+}
+
+// ---------------------------------------------------------------------------
+// Heartbeat — keeps lizard mode suppressed and re-sends active rumble
 // ---------------------------------------------------------------------------
 
 void SteamController::HeartbeatLoop() {
@@ -167,22 +333,20 @@ void SteamController::HeartbeatLoop() {
     BuildCmd(buf, CMD_CLEAR_DIGITAL_MAPPINGS);
     int lizardTicks = 0;
 
-    // Fixed 40 ms tick: active rumble must be re-sent roughly every 50 ms or
-    // the controller's safety timeout stops the motors. The lizard-mode
-    // keep-alive only needs ~800 ms, so it fires every 20th tick. Don't sleep
-    // longer when rumble is idle — rumble starting mid-sleep would stutter
-    // until the next tick.
     while (m_running.load()) {
         if (lizardTicks <= 0) {
-            std::lock_guard<std::mutex> lock(m_commandMutex);
+            std::lock_guard<std::mutex> lock(m_writeMutex);
             m_device.SendFeatureReport(buf, sizeof(buf));
             lizardTicks = 20;
         }
 
-        uint16_t leftSpeed = m_rumbleLeft.load();
-        uint16_t rightSpeed = m_rumbleRight.load();
-        if (leftSpeed || rightSpeed)
-            SendRumbleOutput(leftSpeed, rightSpeed);
+        RumbleFrame frame{};
+        {
+            std::lock_guard<std::mutex> lock(m_rumbleMutex);
+            frame = CurrentRumbleFrameLocked(std::chrono::steady_clock::now());
+        }
+        if (frame.left || frame.right)
+            SendRumbleOutput(frame.left, frame.right);
 
         --lizardTicks;
         std::this_thread::sleep_for(std::chrono::milliseconds(40));

--- a/src/steam/SteamController.h
+++ b/src/steam/SteamController.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "hid/HidDevice.h"
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <mutex>
 #include <thread>
@@ -15,11 +16,16 @@ public:
     static constexpr uint16_t VENDOR_USAGE_PAGE = 0xFF00;
 
     // Input report IDs (device → host)
-    static constexpr uint8_t REPORT_STATE         = 0x45;  // 53 bytes: main controller state (changed from 0x42 in firmware update)
-    static constexpr uint8_t REPORT_SECONDARY      = 0x43;  // 14 bytes: gyro / secondary state
-    static constexpr uint8_t REPORT_STATUS         = 0x44;  //  5 bytes: battery / connection
-    static constexpr uint8_t REPORT_UNKNOWN_7B     = 0x7B;  // 12 bytes: TBD
-    static constexpr uint8_t REPORT_UNKNOWN_79     = 0x79;  //  1 byte:  TBD
+    static constexpr uint8_t REPORT_STATE         = 0x45;  // BLE/no-quaternion state report
+    static constexpr uint8_t REPORT_STATE_LEGACY  = 0x42;  // USB/full state report (same layout)
+    static constexpr uint8_t REPORT_BATTERY_STATUS = 0x43; // TritonBatteryStatus_t
+    static constexpr uint8_t REPORT_STATUS         = 0x44; //  5 bytes: battery / connection
+    static constexpr uint8_t REPORT_UNKNOWN_7B     = 0x7B; // 12 bytes: TBD
+    static constexpr uint8_t REPORT_UNKNOWN_79     = 0x79; //  1 byte:  TBD
+
+    static constexpr uint8_t CHARGE_STATE_DISCHARGING   = 1;
+    static constexpr uint8_t CHARGE_STATE_CHARGING      = 2;
+    static constexpr uint8_t CHARGE_STATE_CHARGING_DONE = 4;
 
     // Feature report IDs — the command channel to the firmware.
     // Commands are wrapped inside Feature Report 0x01 (or 0x02 as fallback).
@@ -34,15 +40,22 @@ public:
     static constexpr uint8_t CMD_SET_DEFAULT_MAPPINGS   = 0x85;  // ← lizard on
     static constexpr uint8_t CMD_SET_SETTINGS           = 0x87;
     static constexpr uint8_t CMD_GET_SETTINGS           = 0x89;
-    static constexpr uint8_t OUT_REPORT_HAPTIC_RUMBLE   = 0x80;
+
+    // Triton output report IDs.
+    static constexpr uint8_t OUT_HAPTIC_RUMBLE   = 0x80;  // continuous two-channel haptic
+    static constexpr uint8_t OUT_HAPTIC_PULSE    = 0x81;  // one-shot pulse (on/off/repeat/gain)
+    static constexpr uint8_t OUT_HAPTIC_COMMAND  = 0x82;  // named command (tick/click + gain)
 
     // Setting key IDs (go in the payload of CMD_SET_SETTINGS)
-    static constexpr uint8_t SETTING_RIGHT_TRACKPAD_MODE = 0x07;
-    static constexpr uint8_t SETTING_LEFT_TRACKPAD_MODE  = 0x08;
-    static constexpr uint8_t TRACKPAD_NONE               = 0x00;
+    static constexpr uint8_t  SETTING_RIGHT_TRACKPAD_MODE = 0x07;
+    static constexpr uint8_t  SETTING_LEFT_TRACKPAD_MODE  = 0x08;
+    static constexpr uint8_t  SETTING_IMU_MODE            = 0x30;
+    static constexpr uint8_t  TRACKPAD_NONE               = 0x00;
+    static constexpr uint16_t IMU_MODE_OFF                = 0x0000;
+    static constexpr uint16_t IMU_MODE_RAW_ACCEL_GYRO     = 0x0018;
 
     // ---------------------------------------------------------------------------
-    // Input report layout — 0x45 STATE report (buf[0] = 0x45)
+    // Input report layout — 0x45 / 0x42 STATE report (buf[0] = 0x45 or 0x42)
     // ---------------------------------------------------------------------------
 
     // buf[01]       — 8-bit sequence counter (wraps 0xFF → 0x00)
@@ -68,22 +81,22 @@ public:
     static constexpr uint8_t BTN_LS       = 0x80;  // bit 7 — left stick click
 
     // buf[04]       — button bitmask byte 2
-    static constexpr uint8_t BTN_STEAM    = 0x01;  // bit 0 — Steam / Guide
-    static constexpr uint8_t BTN_L4       = 0x02;  // bit 1 — back paddle L4
-    static constexpr uint8_t BTN_L5       = 0x04;  // bit 2 — back paddle L5
-    static constexpr uint8_t BTN_LB       = 0x08;  // bit 3
-    static constexpr uint8_t BTN_RS_TOUCH  = 0x10;  // bit 4 — right stick capacitive touch
-    static constexpr uint8_t BTN_TP_RT    = 0x20;  // bit 5 — right trackpad active (touch or click)
-    // bit 6 (0x40): TBD — possibly right trackpad physical click (hard press only)
-    static constexpr uint8_t BTN_RT_FULL  = 0x80;  // bit 7 — right trigger fully pressed (digital threshold)
+    static constexpr uint8_t BTN_STEAM       = 0x01;  // bit 0 — Steam / Guide
+    static constexpr uint8_t BTN_L4          = 0x02;  // bit 1 — back paddle L4
+    static constexpr uint8_t BTN_L5          = 0x04;  // bit 2 — back paddle L5
+    static constexpr uint8_t BTN_LB          = 0x08;  // bit 3
+    static constexpr uint8_t BTN_RS_TOUCH    = 0x10;  // bit 4 — right stick capacitive touch
+    static constexpr uint8_t BTN_TP_RT       = 0x20;  // bit 5 — right trackpad active (touch or click)
+    static constexpr uint8_t BTN_TP_RT_CLICK = 0x40;  // bit 6 — right trackpad hard press (physical click)
+    static constexpr uint8_t BTN_RT_FULL     = 0x80;  // bit 7 — right trigger fully pressed (digital threshold)
 
     // buf[05]       — flags byte
     static constexpr uint8_t BTN_LS_TOUCH    = 0x01;  // bit 0 — left stick capacitive touch
-    static constexpr uint8_t BTN_TP_LT      = 0x02;  // bit 1 — left trackpad active (touch or click)
-    static constexpr uint8_t BTN_TP_LT_CLICK = 0x04; // bit 2 — left trackpad hard press
+    static constexpr uint8_t BTN_TP_LT       = 0x02;  // bit 1 — left trackpad active (touch or click)
+    static constexpr uint8_t BTN_TP_LT_CLICK = 0x04;  // bit 2 — left trackpad hard press
     // bit 3 (0x08): TBD
-    static constexpr uint8_t FLAG_GRIP_RT = 0x10;  // bit 4 — right grip sensor active
-    static constexpr uint8_t FLAG_GRIP_LT = 0x20;  // bit 5 — left grip sensor active
+    static constexpr uint8_t FLAG_GRIP_RT    = 0x10;  // bit 4 — right grip sensor active
+    static constexpr uint8_t FLAG_GRIP_LT    = 0x20;  // bit 5 — left grip sensor active
     // other bits TBD
 
     // buf[06..07]   — left trigger,  16-bit LE signed, 0x0000 (released) – 0x7FFF (full)
@@ -102,11 +115,15 @@ public:
     // buf[26..27]   — right trackpad Y, 16-bit LE signed (0x0000 when not touching)
     // buf[28..29]   — right trackpad contact area, 16-bit LE (0 = no contact; higher = more area/pressure)
 
-    // buf[30..31]   — 0x03 0x46 constant (firmware info?)
-    // buf[32..39]   — IMU quaternion (4× 16-bit LE, little-endian)
-    // buf[40..43]   — unknown / always zero
-    // buf[44..45]   — 0xFF 0xFF at full charge (battery level)
-    // buf[46..53]   — gyro at rest (constant when stationary)
+    // IMU data — only present when IMU is enabled (SETTING_IMU_MODE = IMU_MODE_RAW_ACCEL_GYRO).
+    // Report length grows to ≥ 46 bytes.
+    // buf[30..33]   — IMU timestamp, 32-bit LE unsigned (units ~16 µs)
+    // buf[34..35]   — accelerometer X, 16-bit LE signed
+    // buf[36..37]   — accelerometer Y, 16-bit LE signed
+    // buf[38..39]   — accelerometer Z, 16-bit LE signed
+    // buf[40..41]   — gyroscope X, 16-bit LE signed
+    // buf[42..43]   — gyroscope Y, 16-bit LE signed
+    // buf[44..45]   — gyroscope Z, 16-bit LE signed
 
     // ---------------------------------------------------------------------------
 
@@ -125,6 +142,11 @@ public:
     void Close();
     bool IsOpen() const { return m_device.IsOpen(); }
 
+    // Returns true for any report ID that carries controller state.
+    static bool IsStateReportId(uint8_t id) {
+        return id == REPORT_STATE || id == REPORT_STATE_LEGACY;
+    }
+
     // Two-step sequence: clears digital mappings + sets trackpads to NONE.
     // Starts the background heartbeat thread on first call.
     bool DisableLizardMode();
@@ -136,17 +158,51 @@ public:
     // Returns 0 on timeout.
     size_t ReadReport(uint8_t* buffer, size_t size, uint32_t timeoutMs = 16);
 
-    // Sends a Steam Controller haptic rumble command. Speeds are 0..65535.
-    bool SetRumble(uint16_t leftSpeed, uint16_t rightSpeed);
+    // Enable or disable raw IMU (accel + gyro) output in the state report.
+    bool SetImuEnabled(bool enabled);
+
+    // Set rumble intensity from XInput/DS4 motor bytes (0–255 each).
+    // Uses a power curve, cross-channel mixing, and a short attack boost on
+    // rising edges to produce a more natural feel from the haptic actuators.
+    // Call with (0, 0) to stop rumble.
+    void SetRumble(uint8_t largeMotor, uint8_t smallMotor);
+
+    // Fire a single haptic event on one trackpad.
+    // strongClick = true → physical-click sensation; false → light movement tick.
+    void PulseTrackpadHaptic(bool left, bool strongClick);
+
+    // Silence any in-flight trackpad haptic state (lifecycle cleanup hook).
+    void ClearTrackpadHaptics();
 
 private:
-    void HeartbeatLoop();
-    bool SendRumbleOutput(uint16_t leftSpeed, uint16_t rightSpeed);
+    struct RumbleFrame {
+        uint16_t left  = 0;
+        uint16_t right = 0;
+    };
 
-    HidDevice       m_device;
-    std::thread     m_heartbeat;
+    void HeartbeatLoop();
+    RumbleFrame CurrentRumbleFrameLocked(std::chrono::steady_clock::time_point now) const;
+    bool SendRumbleOutput(uint16_t leftSpeed, uint16_t rightSpeed);
+    bool SendTrackpadPulseOutput(uint8_t side, uint16_t onUs, uint16_t offUs,
+                                  uint16_t repeatCount, int16_t gainDb);
+    bool SendTrackpadCommandOutput(uint8_t side, uint8_t command, int8_t gainDb);
+
+    HidDevice         m_device;
+    std::thread       m_heartbeat;
     std::atomic<bool> m_running{false};
-    std::atomic<uint16_t> m_rumbleLeft{0};
-    std::atomic<uint16_t> m_rumbleRight{0};
-    std::mutex      m_commandMutex;
+
+    // Shared by the heartbeat thread and callers — protect with m_writeMutex.
+    std::mutex        m_writeMutex;
+
+    // Rumble state — protect with m_rumbleMutex.
+    std::mutex        m_rumbleMutex;
+    uint16_t          m_rumbleBaseLeft   = 0;
+    uint16_t          m_rumbleBaseRight  = 0;
+    uint16_t          m_rumbleBoostLeft  = 0;
+    uint16_t          m_rumbleBoostRight = 0;
+    std::chrono::steady_clock::time_point m_rumbleBoostUntil{};
+    std::chrono::steady_clock::time_point m_lastRumbleSent{};
+    uint8_t           m_lastLargeMotor   = 0;
+    uint8_t           m_lastSmallMotor   = 0;
+    bool              m_hasRumbleState   = false;
 };

--- a/third_party/ViGEmClient-b66d02d/include/ViGEm/Client.h
+++ b/third_party/ViGEmClient-b66d02d/include/ViGEm/Client.h
@@ -1,0 +1,658 @@
+/*
+MIT License
+
+Copyright (c) 2017-2023 Nefarius Software Solutions e.U. and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+
+#ifndef ViGEmClient_h__
+#define ViGEmClient_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ViGEm/Common.h"
+
+#ifdef VIGEM_DYNAMIC
+#ifdef VIGEM_EXPORTS
+#define VIGEM_API __declspec(dllexport)
+#else
+#define VIGEM_API __declspec(dllimport)
+#endif
+#else
+#define VIGEM_API
+#endif
+
+#if defined(_MSC_VER)
+#define VIGEM_DEPRECATED __declspec(deprecated)
+#elif defined(__GNUC__)
+#define VIGEM_DEPRECATED __attribute__ ((deprecated))
+#endif
+
+	/** Values that represent ViGEm errors */
+	typedef enum _VIGEM_ERRORS
+	{
+		//
+		// API succeeded.
+		// 
+		VIGEM_ERROR_NONE = 0x20000000,
+		//
+		// A compatible bus driver wasn't found on the system.
+		// 
+		VIGEM_ERROR_BUS_NOT_FOUND = 0xE0000001,
+		//
+		// All device slots are occupied, no new device can be spawned.
+		// 
+		VIGEM_ERROR_NO_FREE_SLOT = 0xE0000002,
+		VIGEM_ERROR_INVALID_TARGET = 0xE0000003,
+		VIGEM_ERROR_REMOVAL_FAILED = 0xE0000004,
+		//
+		// An attempt has been made to plug in an already connected device.
+		// 
+		VIGEM_ERROR_ALREADY_CONNECTED = 0xE0000005,
+		//
+		// The target device is not initialized.
+		// 
+		VIGEM_ERROR_TARGET_UNINITIALIZED = 0xE0000006,
+		//
+		// The target device is not plugged in.
+		// 
+		VIGEM_ERROR_TARGET_NOT_PLUGGED_IN = 0xE0000007,
+		//
+		// It's been attempted to communicate with an incompatible driver version.
+		// 
+		VIGEM_ERROR_BUS_VERSION_MISMATCH = 0xE0000008,
+		//
+		// Bus driver found but failed to open a handle.
+		// 
+		VIGEM_ERROR_BUS_ACCESS_FAILED = 0xE0000009,
+		VIGEM_ERROR_CALLBACK_ALREADY_REGISTERED = 0xE0000010,
+		VIGEM_ERROR_CALLBACK_NOT_FOUND = 0xE0000011,
+		VIGEM_ERROR_BUS_ALREADY_CONNECTED = 0xE0000012,
+		VIGEM_ERROR_BUS_INVALID_HANDLE = 0xE0000013,
+		VIGEM_ERROR_XUSB_USERINDEX_OUT_OF_RANGE = 0xE0000014,
+		VIGEM_ERROR_INVALID_PARAMETER = 0xE0000015,
+		//
+		// The API is not supported by the driver.
+		// 
+		VIGEM_ERROR_NOT_SUPPORTED = 0xE0000016,
+		//
+		// An unexpected Win32 API error occurred. Call GetLastError() for details.
+		// 
+		VIGEM_ERROR_WINAPI = 0xE0000017,
+		//
+		// The specified timeout has been reached.
+		// 
+		VIGEM_ERROR_TIMED_OUT = 0xE0000018,
+		VIGEM_ERROR_IS_DISPOSING = 0xE0000019,
+	} VIGEM_ERROR;
+
+	/**
+	 * A macro that defines if the API succeeded
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	01.09.2020
+	 *
+	 * @param 	_val_	The error value.
+	 */
+#define VIGEM_SUCCESS(_val_) (_val_ == VIGEM_ERROR_NONE)
+
+	 /** Defines an alias representing a driver connection object */
+	typedef struct _VIGEM_CLIENT_T *PVIGEM_CLIENT;
+
+	/** Defines an alias representing a target device object */
+	typedef struct _VIGEM_TARGET_T *PVIGEM_TARGET;
+
+	typedef _Function_class_(EVT_VIGEM_TARGET_ADD_RESULT)
+		VOID CALLBACK
+		EVT_VIGEM_TARGET_ADD_RESULT(
+			PVIGEM_CLIENT Client,
+			PVIGEM_TARGET Target,
+			VIGEM_ERROR Result
+		);
+
+	typedef EVT_VIGEM_TARGET_ADD_RESULT *PFN_VIGEM_TARGET_ADD_RESULT;
+
+	typedef _Function_class_(EVT_VIGEM_X360_NOTIFICATION)
+		VOID CALLBACK
+		EVT_VIGEM_X360_NOTIFICATION(
+			PVIGEM_CLIENT Client,
+			PVIGEM_TARGET Target,
+			UCHAR LargeMotor,
+			UCHAR SmallMotor,
+			UCHAR LedNumber,
+			LPVOID UserData
+		);
+
+	typedef EVT_VIGEM_X360_NOTIFICATION *PFN_VIGEM_X360_NOTIFICATION;
+
+	typedef _Function_class_(EVT_VIGEM_DS4_NOTIFICATION)
+		VOID CALLBACK
+		EVT_VIGEM_DS4_NOTIFICATION(
+			PVIGEM_CLIENT Client,
+			PVIGEM_TARGET Target,
+			UCHAR LargeMotor,
+			UCHAR SmallMotor,
+			DS4_LIGHTBAR_COLOR LightbarColor,
+			LPVOID UserData
+		);
+
+	typedef EVT_VIGEM_DS4_NOTIFICATION *PFN_VIGEM_DS4_NOTIFICATION;
+
+	/**
+	 *  Allocates an object representing a driver connection
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @returns	A PVIGEM_CLIENT object.
+	 */
+	VIGEM_API PVIGEM_CLIENT vigem_alloc(void);
+
+	/**
+	 * Frees up memory used by the driver connection object
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem	The PVIGEM_CLIENT object.
+	 */
+	VIGEM_API void vigem_free(
+		PVIGEM_CLIENT vigem
+	);
+
+	/**
+	 * Initializes the driver object and establishes a connection to the emulation bus
+	 *          driver. Returns an error if no compatible bus device has been found.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem	The PVIGEM_CLIENT object.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_connect(
+		PVIGEM_CLIENT vigem
+	);
+
+	/**
+	 * Disconnects from the bus device and resets the driver object state. The driver object
+	 *           may be reused again after calling this function. When called, all targets which may
+	 *           still be connected will be destroyed automatically. Be aware, that allocated target
+	 *           objects won't be automatically freed, this has to be taken care of by the caller.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem	The PVIGEM_CLIENT object.
+	 */
+	VIGEM_API void vigem_disconnect(
+		PVIGEM_CLIENT vigem
+	);
+
+	/**
+	 * A useful utility function to check if pre 1.17 driver, meant to be replaced in the future by
+	 *          more robust version checks, only able to be checked after at least one device has been
+	 *          successfully plugged in.
+	 *
+	 * @author	Jason "megadrago88" Hart
+	 * @date	17.08.2021
+	 *
+	 * @param   target  The PVIGEM_TARGET to check against.
+	 *
+	 * @returns	A BOOLEAN, true if the device wait ready ioctl is supported (1.17+) or false if not ( =< 1.16)
+	 */
+	VIGEM_API BOOLEAN vigem_target_is_waitable_add_supported(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Allocates an object representing an Xbox 360 Controller device.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @returns	A PVIGEM_TARGET representing an Xbox 360 Controller device.
+	 */
+	VIGEM_API PVIGEM_TARGET vigem_target_x360_alloc(void);
+
+	/**
+	 * Allocates an object representing a DualShock 4 Controller device.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @returns	A PVIGEM_TARGET representing a DualShock 4 Controller device.
+	 */
+	VIGEM_API PVIGEM_TARGET vigem_target_ds4_alloc(void);
+
+	/**
+	 * Frees up memory used by the target device object. This does not automatically remove
+	 *          the associated device from the bus, if present. If the target device doesn't get
+	 *          removed before this call, the device becomes orphaned until the owning process is
+	 *          terminated.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 */
+	VIGEM_API void vigem_target_free(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Adds a provided target device to the bus driver, which is equal to a device plug-in
+	 *          event of a physical hardware device. This function blocks until the target device is
+	 *          in full operational mode.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_add(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Adds a provided target device to the bus driver, which is equal to a device plug-in
+	 *          event of a physical hardware device. This function immediately returns. An optional
+	 *          callback may be registered which gets called on error or if the target device has
+	 *          become fully operational.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 * @param 	result	An optional function getting called when the target device becomes available.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_add_async(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		PFN_VIGEM_TARGET_ADD_RESULT result
+	);
+
+	/**
+	 * Removes a provided target device from the bus driver, which is equal to a device
+	 *           unplug event of a physical hardware device. The target device object may be reused
+	 *           after this function is called. If this function is never called on target device
+	 *           objects, they will be removed from the bus when the owning process terminates.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_remove(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Registers a function which gets called, when LED index or vibration state changes
+	 *                 occur on the provided target device. This function fails if the provided
+	 *                 target device isn't fully operational or in an erroneous state.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem			The driver connection object.
+	 * @param 	target			The target device object.
+	 * @param 	notification	The notification callback.
+	 * @param 	userData		The user data passed to the notification callback.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_x360_register_notification(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		PFN_VIGEM_X360_NOTIFICATION notification,
+		LPVOID userData
+	);
+
+	/**
+	 * This function is deprecated, use vigem_target_ds4_await_output_report or
+	 * vigem_target_ds4_await_output_report_timeout instead. Registers a function which gets called,
+	 * when LightBar or vibration state changes occur on the provided target device. This function
+	 * fails if the provided target device isn't fully operational or in an erroneous state.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem			The driver connection object.
+	 * @param 	target			The target device object.
+	 * @param 	notification	The notification callback.
+	 * @param 	userData		The user data passed to the notification callback.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_DEPRECATED VIGEM_ERROR vigem_target_ds4_register_notification(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		PFN_VIGEM_DS4_NOTIFICATION notification,
+		LPVOID userData
+	);
+
+	/**
+	 * Removes a previously registered callback function from the provided target object.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 */
+	VIGEM_API void vigem_target_x360_unregister_notification(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Removes a previously registered callback function from the provided target object.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 */
+	VIGEM_API VIGEM_DEPRECATED void vigem_target_ds4_unregister_notification(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Overrides the default Vendor ID value with the provided one.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 * @param 	vid   	The Vendor ID to set.
+	 */
+	VIGEM_API void vigem_target_set_vid(
+		PVIGEM_TARGET target,
+		USHORT vid
+	);
+
+	/**
+	 * Overrides the default Product ID value with the provided one.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 * @param 	pid   	The Product ID to set.
+	 */
+	VIGEM_API void vigem_target_set_pid(
+		PVIGEM_TARGET target,
+		USHORT pid
+	);
+
+	/**
+	 * Returns the Vendor ID of the provided target device object.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 *
+	 * @returns	The Vendor ID.
+	 */
+	VIGEM_API USHORT vigem_target_get_vid(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Returns the Product ID of the provided target device object.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 *
+	 * @returns	The Product ID.
+	 */
+	VIGEM_API USHORT vigem_target_get_pid(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Sends a state report to the provided target device.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 * @param 	report	The report to send to the target device.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_x360_update(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		XUSB_REPORT report
+	);
+
+	/**
+	 * DEPRECATED. Sends a state report to the provided target device. It's recommended to use
+	 * vigem_target_ds4_update_ex instead to utilize all DS4 features like touch, gyro etc.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 * @param 	report	The report to send to the target device.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_ds4_update(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		DS4_REPORT report
+	);
+
+	/**
+	 * Sends a full size state report to the provided target device. It's recommended to use this
+	 * function over vigem_target_ds4_update.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	07.09.2020
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 * @param 	report	The report buffer.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_ds4_update_ex(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		DS4_REPORT_EX report
+	);
+
+	/**
+	 * Returns the internal index (serial number) the bus driver assigned to the provided
+	 *               target device object. Note that this value is specific to the inner workings of
+	 *               the bus driver, it does not reflect related values like player index or device
+	 *               arrival order experienced by other APIs. It may be used to identify the target
+	 *               device object for its lifetime. This value becomes invalid once the target
+	 *               device is removed from the bus and may change on the next addition of the
+	 *               device.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 *
+	 * @returns	The internally used index of the target device.
+	 */
+	VIGEM_API ULONG vigem_target_get_index(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Returns the type of the provided target device object.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	28.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 *
+	 * @returns	A VIGEM_TARGET_TYPE.
+	 */
+	VIGEM_API VIGEM_TARGET_TYPE vigem_target_get_type(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Returns TRUE if the provided target device object is currently attached to the bus,
+	 *              FALSE otherwise.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	30.08.2017
+	 *
+	 * @param 	target	The target device object.
+	 *
+	 * @returns	TRUE if device is attached to the bus, FALSE otherwise.
+	 */
+	VIGEM_API BOOL vigem_target_is_attached(
+		PVIGEM_TARGET target
+	);
+
+	/**
+	 * Returns the user index of the emulated Xenon device. This value correspondents to the
+	 *                (zero-based) index number representing the player number via LED present on a
+	 *                physical controller and is compatible to the dwUserIndex property of the
+	 *                XInput* APIs.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger
+	 * @date	10.05.2018
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 * @param 	index 	The (zero-based) user index of the Xenon device.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_x360_get_user_index(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		PULONG index
+	);
+
+	/**
+	 * Waits until there's one or more pending raw output reports available to consume. This
+	 * function blocks until data becomes available or the device gets disconnected. The waiting is
+	 * event-based, meaning that as soon as a data packet is pending, this call returns a copy of
+	 * the entire buffer. Each call returns a packet in the exact order it arrived in the driver. It
+	 * is recommended to repeatedly call this function in a thread. The call aborts with an error
+	 * code if the target gets unplugged in parallel.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	06.08.2022
+	 *
+	 * @param 	vigem 	The driver connection object.
+	 * @param 	target	The target device object.
+	 * @param 	buffer	The fixed-size 64-bytes output report buffer that gets written to.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_ds4_await_output_report(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		PDS4_OUTPUT_BUFFER buffer
+	);
+
+	/**
+	 * Waits until there's one or more pending raw output reports available to consume. This
+	 * function blocks until data becomes available, the provided timeout has been reached or the
+	 * device gets disconnected. The waiting is event-based, meaning that as soon as a data packet
+	 * is pending, this call returns a copy of the entire buffer. Each call returns a packet in the
+	 * exact order it arrived in the driver. It is recommended to repeatedly call this function in a
+	 * thread. A timeout of a few hundred milliseconds can be used to break out of the loop without
+	 * excessive CPU consumption. The call aborts with an error code if the target gets unplugged in
+	 * parallel. If a timeout of INFINITE is specified, the function basically behaves identical to
+	 * vigem_target_ds4_await_output_report.
+	 *
+	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @date	12.08.2022
+	 *
+	 * @param 	vigem			The driver connection object.
+	 * @param 	target			The target device object.
+	 * @param 	milliseconds	The timeout in milliseconds.
+	 * @param 	buffer			The fixed-size 64-bytes output report buffer that gets written to.
+	 *
+	 * @returns	A VIGEM_ERROR.
+	 */
+	VIGEM_API VIGEM_ERROR vigem_target_ds4_await_output_report_timeout(
+		PVIGEM_CLIENT vigem,
+		PVIGEM_TARGET target,
+		DWORD milliseconds,
+		PDS4_OUTPUT_BUFFER buffer
+	);
+
+    /**
+     * Returns the output data of the Xbox gamepad. Output refers to the USB output report, which
+     *                is used to set LEDs and motor values.
+     *
+     * @author  Matt Wszolek
+     * @date    09.28.2021
+     *
+     * @param   vigem   The driver connection object.
+     * @param   target  The target device object.
+     * @param   output  The values that are set by the output reports
+     *
+     * @returns A VIGEM_ERROR.
+     */
+    VIGEM_API VIGEM_ERROR vigem_target_x360_get_output(PVIGEM_CLIENT vigem, PVIGEM_TARGET target, PXUSB_OUTPUT_DATA output);
+
+    /**
+     * Returns the output data of the DualShock 4 gamepad. Output refers to the USB output report,
+     *                which is used to set LED and motor values.
+     *
+     * @author  Matt Wszolek
+     * @date    09.28.2021
+     *
+     * @param   vigem   The driver connection object.
+     * @param   target  The target device object.
+     * @param   output  The values that are set by the output reports
+     *
+     * @returns A VIGEM_ERROR.
+     */
+    VIGEM_API VIGEM_ERROR vigem_target_ds4_get_output(PVIGEM_CLIENT vigem, PVIGEM_TARGET target, PDS4_OUTPUT_DATA output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ViGEmClient_h__

--- a/third_party/ViGEmClient-b66d02d/include/ViGEm/Common.h
+++ b/third_party/ViGEmClient-b66d02d/include/ViGEm/Common.h
@@ -1,0 +1,285 @@
+/*
+MIT License
+
+Copyright (c) 2017-2023 Nefarius Software Solutions e.U. and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+
+#pragma once
+
+//
+// Represents the desired target type for the emulated device.
+//  
+typedef enum _VIGEM_TARGET_TYPE
+{
+    // 
+    // Microsoft Xbox 360 Controller (wired)
+    // 
+    Xbox360Wired = 0,
+    //
+    // Sony DualShock 4 (wired)
+    // 
+    DualShock4Wired = 2 // NOTE: 1 skipped on purpose to maintain compatibility
+
+} VIGEM_TARGET_TYPE, *PVIGEM_TARGET_TYPE;
+
+//
+// Possible XUSB report buttons.
+// 
+typedef enum _XUSB_BUTTON
+{
+    XUSB_GAMEPAD_DPAD_UP            = 0x0001,
+    XUSB_GAMEPAD_DPAD_DOWN          = 0x0002,
+    XUSB_GAMEPAD_DPAD_LEFT          = 0x0004,
+    XUSB_GAMEPAD_DPAD_RIGHT         = 0x0008,
+    XUSB_GAMEPAD_START              = 0x0010,
+    XUSB_GAMEPAD_BACK               = 0x0020,
+    XUSB_GAMEPAD_LEFT_THUMB         = 0x0040,
+    XUSB_GAMEPAD_RIGHT_THUMB        = 0x0080,
+    XUSB_GAMEPAD_LEFT_SHOULDER      = 0x0100,
+    XUSB_GAMEPAD_RIGHT_SHOULDER     = 0x0200,
+    XUSB_GAMEPAD_GUIDE              = 0x0400,
+    XUSB_GAMEPAD_A                  = 0x1000,
+    XUSB_GAMEPAD_B                  = 0x2000,
+    XUSB_GAMEPAD_X                  = 0x4000,
+    XUSB_GAMEPAD_Y                  = 0x8000
+
+} XUSB_BUTTON, *PXUSB_BUTTON;
+
+//
+// Represents an XINPUT_GAMEPAD-compatible report structure.
+// 
+typedef struct _XUSB_REPORT
+{
+    USHORT wButtons;
+    BYTE bLeftTrigger;
+    BYTE bRightTrigger;
+    SHORT sThumbLX;
+    SHORT sThumbLY;
+    SHORT sThumbRX;
+    SHORT sThumbRY;
+
+} XUSB_REPORT, *PXUSB_REPORT;
+
+//
+// Initializes a _XUSB_REPORT structure.
+// 
+VOID FORCEINLINE XUSB_REPORT_INIT(
+    _Out_ PXUSB_REPORT Report
+)
+{
+    RtlZeroMemory(Report, sizeof(XUSB_REPORT));
+}
+
+//
+// Values set by output reports on XINPUT_GAMEPAD
+//
+typedef struct _XUSB_OUTPUT_DATA
+{
+    UCHAR LargeMotor;
+    UCHAR SmallMotor;
+    UCHAR LedNumber;
+} XUSB_OUTPUT_DATA, *PXUSB_OUTPUT_DATA;
+
+//
+// The color value (RGB) of a DualShock 4 Lightbar
+// 
+typedef struct _DS4_LIGHTBAR_COLOR
+{
+    //
+    // Red part of the Lightbar (0-255).
+    //
+    UCHAR Red;
+
+    //
+    // Green part of the Lightbar (0-255).
+    //
+    UCHAR Green;
+
+    //
+    // Blue part of the Lightbar (0-255).
+    //
+    UCHAR Blue;
+
+} DS4_LIGHTBAR_COLOR, *PDS4_LIGHTBAR_COLOR;
+
+//
+// DualShock 4 digital buttons
+// 
+typedef enum _DS4_BUTTONS
+{
+    DS4_BUTTON_THUMB_RIGHT      = 1 << 15,
+    DS4_BUTTON_THUMB_LEFT       = 1 << 14,
+    DS4_BUTTON_OPTIONS          = 1 << 13,
+    DS4_BUTTON_SHARE            = 1 << 12,
+    DS4_BUTTON_TRIGGER_RIGHT    = 1 << 11,
+    DS4_BUTTON_TRIGGER_LEFT     = 1 << 10,
+    DS4_BUTTON_SHOULDER_RIGHT   = 1 << 9,
+    DS4_BUTTON_SHOULDER_LEFT    = 1 << 8,
+    DS4_BUTTON_TRIANGLE         = 1 << 7,
+    DS4_BUTTON_CIRCLE           = 1 << 6,
+    DS4_BUTTON_CROSS            = 1 << 5,
+    DS4_BUTTON_SQUARE           = 1 << 4
+
+} DS4_BUTTONS, *PDS4_BUTTONS;
+
+//
+// DualShock 4 special buttons
+// 
+typedef enum _DS4_SPECIAL_BUTTONS
+{
+    DS4_SPECIAL_BUTTON_PS           = 1 << 0,
+    DS4_SPECIAL_BUTTON_TOUCHPAD     = 1 << 1
+
+} DS4_SPECIAL_BUTTONS, *PDS4_SPECIAL_BUTTONS;
+
+//
+// DualShock 4 directional pad (HAT) values
+// 
+typedef enum _DS4_DPAD_DIRECTIONS
+{
+    DS4_BUTTON_DPAD_NONE        = 0x8,
+    DS4_BUTTON_DPAD_NORTHWEST   = 0x7,
+    DS4_BUTTON_DPAD_WEST        = 0x6,
+    DS4_BUTTON_DPAD_SOUTHWEST   = 0x5,
+    DS4_BUTTON_DPAD_SOUTH       = 0x4,
+    DS4_BUTTON_DPAD_SOUTHEAST   = 0x3,
+    DS4_BUTTON_DPAD_EAST        = 0x2,
+    DS4_BUTTON_DPAD_NORTHEAST   = 0x1,
+    DS4_BUTTON_DPAD_NORTH       = 0x0
+
+} DS4_DPAD_DIRECTIONS, *PDS4_DPAD_DIRECTIONS;
+
+//
+// DualShock 4 HID Input report
+// 
+typedef struct _DS4_REPORT
+{
+    BYTE bThumbLX;
+    BYTE bThumbLY;
+    BYTE bThumbRX;
+    BYTE bThumbRY;
+    USHORT wButtons;
+    BYTE bSpecial;
+    BYTE bTriggerL;
+    BYTE bTriggerR;
+
+} DS4_REPORT, *PDS4_REPORT;
+
+//
+// Sets the current state of the D-PAD on a DualShock 4 report.
+// 
+VOID FORCEINLINE DS4_SET_DPAD(
+    _Out_ PDS4_REPORT Report,
+    _In_ DS4_DPAD_DIRECTIONS Dpad
+)
+{
+    Report->wButtons &= ~0xF;
+    Report->wButtons |= (USHORT)Dpad;
+}
+
+VOID FORCEINLINE DS4_REPORT_INIT(
+    _Out_ PDS4_REPORT Report
+)
+{
+    RtlZeroMemory(Report, sizeof(DS4_REPORT));
+
+    Report->bThumbLX = 0x80;
+    Report->bThumbLY = 0x80;
+    Report->bThumbRX = 0x80;
+    Report->bThumbRY = 0x80;
+
+    DS4_SET_DPAD(Report, DS4_BUTTON_DPAD_NONE);
+}
+
+//
+// Values set by output reports on DualShock 4
+//
+typedef struct _DS4_OUTPUT_DATA
+{
+    UCHAR LargeMotor;
+    UCHAR SmallMotor;
+    DS4_LIGHTBAR_COLOR LightbarColor;
+} DS4_OUTPUT_DATA, *PDS4_OUTPUT_DATA;
+
+#include <pshpack1.h> // pack structs tightly
+//
+// DualShock 4 HID Touchpad structure
+//
+typedef struct _DS4_TOUCH
+{
+    BYTE bPacketCounter;    // timestamp / packet counter associated with touch event
+    BYTE bIsUpTrackingNum1; // 0 means down; active low
+                            // unique to each finger down, so for a lift and repress the value is incremented
+    BYTE bTouchData1[3];    // Two 12 bits values (for X and Y) 
+                            // middle byte holds last 4 bits of X and the starting 4 bits of Y
+    BYTE bIsUpTrackingNum2; // second touch data immediately follows data of first touch 
+    BYTE bTouchData2[3];    // resolution is 1920x943
+} DS4_TOUCH, * PDS4_TOUCH;
+
+//
+// DualShock 4 v1 complete HID Input report
+//
+typedef struct _DS4_REPORT_EX
+{
+	union
+	{
+		struct
+		{
+			BYTE bThumbLX;
+			BYTE bThumbLY;
+			BYTE bThumbRX;
+			BYTE bThumbRY;
+			USHORT wButtons;
+			BYTE bSpecial;
+			BYTE bTriggerL;
+			BYTE bTriggerR;
+			USHORT wTimestamp;
+			BYTE bBatteryLvl;
+			SHORT wGyroX;
+			SHORT wGyroY;
+			SHORT wGyroZ;
+			SHORT wAccelX;
+			SHORT wAccelY;
+			SHORT wAccelZ;
+			BYTE _bUnknown1[5];
+			BYTE bBatteryLvlSpecial;
+			// really should have a enum to show everything that this can represent (USB charging, battery level; EXT, headset, microphone connected)
+			BYTE _bUnknown2[2];
+			BYTE bTouchPacketsN; // 0x00 to 0x03 (USB max)
+			DS4_TOUCH sCurrentTouch;
+			DS4_TOUCH sPreviousTouch[2];
+		} Report;
+
+		UCHAR ReportBuffer[63];
+	};
+} DS4_REPORT_EX, *PDS4_REPORT_EX;
+
+typedef struct _DS4_OUTPUT_BUFFER
+{
+	//
+	// The output report buffer
+	// 
+	_Out_ UCHAR Buffer[64];
+	
+} DS4_OUTPUT_BUFFER, *PDS4_OUTPUT_BUFFER;
+
+#include <poppack.h>

--- a/third_party/ViGEmClient-b66d02d/include/ViGEm/Util.h
+++ b/third_party/ViGEmClient-b66d02d/include/ViGEm/Util.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "ViGEm/Common.h"
+#include <limits.h>
+
+VOID FORCEINLINE XUSB_TO_DS4_REPORT(
+    _Out_ PXUSB_REPORT Input,
+    _Out_ PDS4_REPORT Output
+)
+{
+    if (Input->wButtons & XUSB_GAMEPAD_BACK) Output->wButtons |= DS4_BUTTON_SHARE;
+    if (Input->wButtons & XUSB_GAMEPAD_START) Output->wButtons |= DS4_BUTTON_OPTIONS;
+    if (Input->wButtons & XUSB_GAMEPAD_LEFT_THUMB) Output->wButtons |= DS4_BUTTON_THUMB_LEFT;
+    if (Input->wButtons & XUSB_GAMEPAD_RIGHT_THUMB) Output->wButtons |= DS4_BUTTON_THUMB_RIGHT;
+    if (Input->wButtons & XUSB_GAMEPAD_LEFT_SHOULDER) Output->wButtons |= DS4_BUTTON_SHOULDER_LEFT;
+    if (Input->wButtons & XUSB_GAMEPAD_RIGHT_SHOULDER) Output->wButtons |= DS4_BUTTON_SHOULDER_RIGHT;
+    if (Input->wButtons & XUSB_GAMEPAD_GUIDE) Output->bSpecial |= DS4_SPECIAL_BUTTON_PS;
+    if (Input->wButtons & XUSB_GAMEPAD_A) Output->wButtons |= DS4_BUTTON_CROSS;
+    if (Input->wButtons & XUSB_GAMEPAD_B) Output->wButtons |= DS4_BUTTON_CIRCLE;
+    if (Input->wButtons & XUSB_GAMEPAD_X) Output->wButtons |= DS4_BUTTON_SQUARE;
+    if (Input->wButtons & XUSB_GAMEPAD_Y) Output->wButtons |= DS4_BUTTON_TRIANGLE;
+
+    Output->bTriggerL = Input->bLeftTrigger;
+    Output->bTriggerR = Input->bRightTrigger;
+
+    if (Input->bLeftTrigger > 0)Output->wButtons |= DS4_BUTTON_TRIGGER_LEFT;
+    if (Input->bRightTrigger > 0)Output->wButtons |= DS4_BUTTON_TRIGGER_RIGHT;
+
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_UP) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_NORTH);
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_RIGHT) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_EAST);
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_DOWN) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_SOUTH);
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_LEFT) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_WEST);
+
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_UP
+        && Input->wButtons & XUSB_GAMEPAD_DPAD_RIGHT) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_NORTHEAST);
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_RIGHT
+        && Input->wButtons & XUSB_GAMEPAD_DPAD_DOWN) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_SOUTHEAST);
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_DOWN
+        && Input->wButtons & XUSB_GAMEPAD_DPAD_LEFT) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_SOUTHWEST);
+    if (Input->wButtons & XUSB_GAMEPAD_DPAD_LEFT
+        && Input->wButtons & XUSB_GAMEPAD_DPAD_UP) DS4_SET_DPAD(Output, DS4_BUTTON_DPAD_NORTHWEST);
+
+    Output->bThumbLX = ((Input->sThumbLX + ((USHRT_MAX / 2) + 1)) / 257);
+    Output->bThumbLY = (-(Input->sThumbLY + ((USHRT_MAX / 2) - 1)) / 257);
+    Output->bThumbLY = (Output->bThumbLY == 0) ? 0xFF : Output->bThumbLY;
+    Output->bThumbRX = ((Input->sThumbRX + ((USHRT_MAX / 2) + 1)) / 257);
+    Output->bThumbRY = (-(Input->sThumbRY + ((USHRT_MAX / 2) + 1)) / 257);
+    Output->bThumbRY = (Output->bThumbRY == 0) ? 0xFF : Output->bThumbRY;
+}
+

--- a/third_party/ViGEmClient-b66d02d/include/ViGEm/km/BusShared.h
+++ b/third_party/ViGEmClient-b66d02d/include/ViGEm/km/BusShared.h
@@ -1,0 +1,506 @@
+/*
+MIT License
+
+Copyright (c) 2016-2019 Nefarius Software Solutions e.U. and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+
+//
+// GUID identifying the bus device. Used by client library to detect and communicate.
+// 
+// IMPORTANT: make sure to change this value if you fork it or introduce 
+//				breaking changes!
+// 
+// {96E42B22-F5E9-42F8-B043-ED0F932F014F}
+DEFINE_GUID(GUID_DEVINTERFACE_BUSENUM_VIGEM,
+    0x96E42B22, 0xF5E9, 0x42F8, 0xB0, 0x43, 0xED, 0x0F, 0x93, 0x2F, 0x01, 0x4F);
+
+#pragma once
+
+#include "ViGEm/Common.h"
+
+//
+// Common version for user-mode library and driver compatibility
+// 
+// On initialization, the user-mode library has this number embedded
+// and sends it to the bus on its enumeration. The bus compares this
+// number to the one it was compiled with. If they match, the bus
+// access is permitted and success reported. If they mismatch, an
+// error is reported and the user-mode library skips this instance.
+// 
+#define VIGEM_COMMON_VERSION            0x0001
+
+#define FILE_DEVICE_BUSENUM             FILE_DEVICE_BUS_EXTENDER
+#define BUSENUM_IOCTL(_index_)          CTL_CODE(FILE_DEVICE_BUSENUM, _index_, METHOD_BUFFERED, FILE_READ_DATA)
+#define BUSENUM_W_IOCTL(_index_)        CTL_CODE(FILE_DEVICE_BUSENUM, _index_, METHOD_BUFFERED, FILE_WRITE_DATA)
+#define BUSENUM_R_IOCTL(_index_)        CTL_CODE(FILE_DEVICE_BUSENUM, _index_, METHOD_BUFFERED, FILE_READ_DATA)
+#define BUSENUM_RW_IOCTL(_index_)       CTL_CODE(FILE_DEVICE_BUSENUM, _index_, METHOD_BUFFERED, FILE_WRITE_DATA | FILE_READ_DATA)
+
+#define IOCTL_VIGEM_BASE 0x801
+
+// 
+// IO control codes
+// 
+#define IOCTL_VIGEM_PLUGIN_TARGET           BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x000)
+#define IOCTL_VIGEM_UNPLUG_TARGET           BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x001)
+#define IOCTL_VIGEM_CHECK_VERSION           BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x002)
+#define IOCTL_VIGEM_WAIT_DEVICE_READY       BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x003)
+
+#define IOCTL_XUSB_REQUEST_NOTIFICATION     BUSENUM_RW_IOCTL(IOCTL_VIGEM_BASE + 0x200)
+#define IOCTL_XUSB_SUBMIT_REPORT            BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x201)
+#define IOCTL_DS4_SUBMIT_REPORT             BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x202)
+#define IOCTL_DS4_REQUEST_NOTIFICATION      BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x203)
+//#define IOCTL_XGIP_SUBMIT_REPORT        BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x204)
+//#define IOCTL_XGIP_SUBMIT_INTERRUPT     BUSENUM_W_IOCTL (IOCTL_VIGEM_BASE + 0x205)
+#define IOCTL_XUSB_GET_USER_INDEX           BUSENUM_RW_IOCTL(IOCTL_VIGEM_BASE + 0x206)
+#define IOCTL_DS4_AWAIT_OUTPUT_AVAILABLE    BUSENUM_RW_IOCTL(IOCTL_VIGEM_BASE + 0x207)
+
+
+//
+//  Data structure used in PlugIn and UnPlug ioctls
+//
+
+#pragma region Plugin
+
+//
+// Data structure used in IOCTL_VIGEM_PLUGIN_TARGET requests.
+// 
+typedef struct _VIGEM_PLUGIN_TARGET
+{
+    //
+    // sizeof (struct _BUSENUM_HARDWARE)
+    //
+    IN ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    IN ULONG SerialNo;
+
+    // 
+    // Type of the target device to emulate.
+    // 
+    VIGEM_TARGET_TYPE TargetType;
+
+    //
+    // If set, the vendor ID the emulated device is reporting
+    // 
+    USHORT VendorId;
+
+    //
+    // If set, the product ID the emulated device is reporting
+    // 
+    USHORT ProductId;
+
+} VIGEM_PLUGIN_TARGET, *PVIGEM_PLUGIN_TARGET;
+
+//
+// Initializes a VIGEM_PLUGIN_TARGET structure.
+// 
+VOID FORCEINLINE VIGEM_PLUGIN_TARGET_INIT(
+    _Out_ PVIGEM_PLUGIN_TARGET PlugIn,
+          _In_ ULONG SerialNo,
+          _In_ VIGEM_TARGET_TYPE TargetType
+)
+{
+    RtlZeroMemory(PlugIn, sizeof(VIGEM_PLUGIN_TARGET));
+
+    PlugIn->Size = sizeof(VIGEM_PLUGIN_TARGET);
+    PlugIn->SerialNo = SerialNo;
+    PlugIn->TargetType = TargetType;
+}
+
+#pragma endregion 
+
+#pragma region Unplug
+
+//
+// Data structure used in IOCTL_VIGEM_UNPLUG_TARGET requests.
+// 
+typedef struct _VIGEM_UNPLUG_TARGET
+{
+    //
+    // sizeof (struct _REMOVE_HARDWARE)
+    //
+    IN ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    ULONG SerialNo;
+
+} VIGEM_UNPLUG_TARGET, *PVIGEM_UNPLUG_TARGET;
+
+//
+// Initializes a VIGEM_UNPLUG_TARGET structure.
+// 
+VOID FORCEINLINE VIGEM_UNPLUG_TARGET_INIT(
+    _Out_ PVIGEM_UNPLUG_TARGET UnPlug,
+          _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(UnPlug, sizeof(VIGEM_UNPLUG_TARGET));
+
+    UnPlug->Size = sizeof(VIGEM_UNPLUG_TARGET);
+    UnPlug->SerialNo = SerialNo;
+}
+
+#pragma endregion
+
+#pragma region Check version
+
+typedef struct _VIGEM_CHECK_VERSION
+{
+    IN ULONG Size;
+
+    IN ULONG Version;
+
+} VIGEM_CHECK_VERSION, *PVIGEM_CHECK_VERSION;
+
+VOID FORCEINLINE VIGEM_CHECK_VERSION_INIT(
+    _Out_ PVIGEM_CHECK_VERSION CheckVersion,
+    _In_ ULONG Version
+)
+{
+    RtlZeroMemory(CheckVersion, sizeof(VIGEM_CHECK_VERSION));
+
+    CheckVersion->Size = sizeof(VIGEM_CHECK_VERSION);
+    CheckVersion->Version = Version;
+}
+
+#pragma endregion
+
+#pragma region Wait device ready
+
+typedef struct _VIGEM_WAIT_DEVICE_READY
+{
+    IN ULONG Size;
+
+    IN ULONG SerialNo;
+
+} VIGEM_WAIT_DEVICE_READY, * PVIGEM_WAIT_DEVICE_READY;
+
+VOID FORCEINLINE VIGEM_WAIT_DEVICE_READY_INIT(
+    _Out_ PVIGEM_WAIT_DEVICE_READY WaitReady,
+    _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(WaitReady, sizeof(VIGEM_WAIT_DEVICE_READY));
+
+    WaitReady->Size = sizeof(VIGEM_WAIT_DEVICE_READY);
+    WaitReady->SerialNo = SerialNo;
+}
+
+#pragma endregion 
+
+#pragma region XUSB (aka Xbox 360 device) section
+
+//
+// Data structure used in IOCTL_XUSB_REQUEST_NOTIFICATION requests.
+// 
+typedef struct _XUSB_REQUEST_NOTIFICATION
+{
+    //
+    // sizeof(struct _XUSB_REQUEST_NOTIFICATION)
+    // 
+    ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    ULONG SerialNo;
+
+    //
+    // Vibration intensity value of the large motor (0-255).
+    // 
+    UCHAR LargeMotor;
+
+    //
+    // Vibration intensity value of the small motor (0-255).
+    // 
+    UCHAR SmallMotor;
+
+    //
+    // Index number of the slot/LED that XUSB.sys has assigned.
+    // 
+    UCHAR LedNumber;
+
+} XUSB_REQUEST_NOTIFICATION, *PXUSB_REQUEST_NOTIFICATION;
+
+//
+// Initializes a XUSB_REQUEST_NOTIFICATION structure.
+// 
+VOID FORCEINLINE XUSB_REQUEST_NOTIFICATION_INIT(
+    _Out_ PXUSB_REQUEST_NOTIFICATION Request,
+          _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(Request, sizeof(XUSB_REQUEST_NOTIFICATION));
+
+    Request->Size = sizeof(XUSB_REQUEST_NOTIFICATION);
+    Request->SerialNo = SerialNo;
+}
+
+//
+// Data structure used in IOCTL_XUSB_SUBMIT_REPORT requests.
+// 
+typedef struct _XUSB_SUBMIT_REPORT
+{
+    //
+    // sizeof(struct _XUSB_SUBMIT_REPORT)
+    // 
+    ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    ULONG SerialNo;
+
+    //
+    // Report to submit to the target device.
+    // 
+    XUSB_REPORT Report;
+
+} XUSB_SUBMIT_REPORT, *PXUSB_SUBMIT_REPORT;
+
+//
+// Initializes an XUSB report.
+// 
+VOID FORCEINLINE XUSB_SUBMIT_REPORT_INIT(
+    _Out_ PXUSB_SUBMIT_REPORT Report,
+    _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(Report, sizeof(XUSB_SUBMIT_REPORT));
+
+    Report->Size = sizeof(XUSB_SUBMIT_REPORT);
+    Report->SerialNo = SerialNo;
+}
+
+typedef struct _XUSB_GET_USER_INDEX
+{
+    //
+    // sizeof(struct _XUSB_GET_USER_INDEX)
+    // 
+    ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    ULONG SerialNo;
+
+    //
+    // User index of target device.
+    // 
+    OUT ULONG UserIndex;
+
+} XUSB_GET_USER_INDEX, *PXUSB_GET_USER_INDEX;
+
+//
+// Initializes XUSB_GET_USER_INDEX structure.
+// 
+VOID FORCEINLINE XUSB_GET_USER_INDEX_INIT(
+    _Out_ PXUSB_GET_USER_INDEX GetRequest,
+    _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(GetRequest, sizeof(XUSB_GET_USER_INDEX));
+
+    GetRequest->Size = sizeof(XUSB_GET_USER_INDEX);
+    GetRequest->SerialNo = SerialNo;
+}
+
+#pragma endregion
+
+#pragma region DualShock 4 section
+
+typedef struct _DS4_OUTPUT_REPORT
+{
+    //
+    // Vibration intensity value of the small motor (0-255).
+    // 
+    UCHAR SmallMotor;
+
+    //
+    // Vibration intensity value of the large motor (0-255).
+    // 
+    UCHAR LargeMotor;
+
+    //
+    // Color values of the Lightbar.
+    //
+    DS4_LIGHTBAR_COLOR LightbarColor;
+
+} DS4_OUTPUT_REPORT, *PDS4_OUTPUT_REPORT;
+
+//
+// Data structure used in IOCTL_DS4_REQUEST_NOTIFICATION requests.
+// 
+typedef struct _DS4_REQUEST_NOTIFICATION
+{
+    //
+    // sizeof(struct _XUSB_REQUEST_NOTIFICATION)
+    // 
+    ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    ULONG SerialNo;
+
+    //
+    // The HID output report
+    // 
+    DS4_OUTPUT_REPORT Report;
+
+} DS4_REQUEST_NOTIFICATION, *PDS4_REQUEST_NOTIFICATION;
+
+//
+// Initializes a DS4_REQUEST_NOTIFICATION structure.
+// 
+VOID FORCEINLINE DS4_REQUEST_NOTIFICATION_INIT(
+    _Out_ PDS4_REQUEST_NOTIFICATION Request,
+    _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(Request, sizeof(DS4_REQUEST_NOTIFICATION));
+
+    Request->Size = sizeof(DS4_REQUEST_NOTIFICATION);
+    Request->SerialNo = SerialNo;
+}
+
+//
+// DualShock 4 request data
+// 
+typedef struct _DS4_SUBMIT_REPORT
+{
+    //
+    // sizeof(struct _DS4_SUBMIT_REPORT)
+    // 
+    ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    ULONG SerialNo;
+
+    //
+    // HID Input report
+    // 
+    DS4_REPORT Report;
+
+} DS4_SUBMIT_REPORT, *PDS4_SUBMIT_REPORT;
+
+//
+// Initializes a DualShock 4 report.
+// 
+VOID FORCEINLINE DS4_SUBMIT_REPORT_INIT(
+    _Out_ PDS4_SUBMIT_REPORT Report,
+    _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(Report, sizeof(DS4_SUBMIT_REPORT));
+
+    Report->Size = sizeof(DS4_SUBMIT_REPORT);
+    Report->SerialNo = SerialNo;
+
+    DS4_REPORT_INIT(&Report->Report);
+}
+
+#include <pshpack1.h>
+
+//
+// DualShock 4 extended report request
+// 
+typedef struct _DS4_SUBMIT_REPORT_EX
+{
+    //
+     // sizeof(struct _DS4_SUBMIT_REPORT_EX)
+     // 
+    _In_ ULONG Size;
+
+    //
+    // Serial number of target device.
+    // 
+    _In_ ULONG SerialNo;
+
+    //
+    // Full size HID report excluding fixed Report ID.
+    // 
+    _In_ DS4_REPORT_EX Report;
+
+} DS4_SUBMIT_REPORT_EX, * PDS4_SUBMIT_REPORT_EX;
+
+#include <poppack.h>
+
+//
+// Initializes a DualShock 4 extended report.
+// 
+VOID FORCEINLINE DS4_SUBMIT_REPORT_EX_INIT(
+    _Out_ PDS4_SUBMIT_REPORT_EX Report,
+    _In_ ULONG SerialNo
+)
+{
+    RtlZeroMemory(Report, sizeof(DS4_SUBMIT_REPORT_EX));
+
+    Report->Size = sizeof(DS4_SUBMIT_REPORT_EX);
+    Report->SerialNo = SerialNo;
+}
+
+#pragma endregion
+
+#pragma region DS4 Await Output
+
+#include <pshpack1.h>
+
+typedef struct _DS4_AWAIT_OUTPUT
+{
+	//
+	// sizeof(struct _DS4_AWAIT_OUTPUT)
+	// 
+	_In_ ULONG Size;
+
+	//
+	// Serial number of target device.
+	// 
+	_Inout_ ULONG SerialNo;
+
+    //
+    // The payload
+    // 
+    _Out_ DS4_OUTPUT_BUFFER Report;
+    
+} DS4_AWAIT_OUTPUT, * PDS4_AWAIT_OUTPUT;
+
+#include <poppack.h>
+
+VOID FORCEINLINE DS4_AWAIT_OUTPUT_INIT(
+	_Out_ PDS4_AWAIT_OUTPUT Output,
+    _In_ ULONG SerialNo
+)
+{
+	RtlZeroMemory(Output, sizeof(DS4_AWAIT_OUTPUT));
+
+	Output->Size = sizeof(DS4_AWAIT_OUTPUT);
+    Output->SerialNo = SerialNo;
+}
+
+#pragma endregion

--- a/third_party/ViGEmClient-b66d02d/src/Internal.h
+++ b/third_party/ViGEmClient-b66d02d/src/Internal.h
@@ -1,0 +1,84 @@
+/*
+MIT License
+
+Copyright (c) 2017-2023 Nefarius Software Solutions e.U. and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+
+#pragma once
+
+//
+// TODO: this is... not optimal. Improve in the future.
+// 
+#define VIGEM_TARGETS_MAX   USHRT_MAX
+
+
+//
+// Represents a driver connection object.
+// 
+typedef struct _VIGEM_CLIENT_T
+{
+    HANDLE hBusDevice;
+    HANDLE hDS4OutputReportPickupThread;
+    HANDLE hDS4OutputReportPickupThreadAbortEvent;
+    PVIGEM_TARGET pTargetsList[VIGEM_TARGETS_MAX];
+} VIGEM_CLIENT;
+
+//
+// Represents the (connection) state of a target device object.
+// 
+typedef enum
+{
+    VIGEM_TARGET_NEW,
+    VIGEM_TARGET_INITIALIZED,
+    VIGEM_TARGET_CONNECTED,
+    VIGEM_TARGET_DISCONNECTED
+} VIGEM_TARGET_STATE, *PVIGEM_TARGET_STATE;
+
+//
+// Represents a virtual gamepad object.
+// 
+typedef struct _VIGEM_TARGET_T
+{
+    ULONG Size;
+    ULONG SerialNo;
+    VIGEM_TARGET_STATE State;
+    USHORT VendorId;
+    USHORT ProductId;
+    VIGEM_TARGET_TYPE Type;
+    FARPROC Notification;
+    LPVOID NotificationUserData;
+    BOOLEAN IsWaitReadyUnsupported;
+	HANDLE CancelNotificationThreadEvent;
+    DS4_OUTPUT_BUFFER Ds4CachedOutputReport;
+    HANDLE Ds4CachedOutputReportUpdateAvailable;
+    CRITICAL_SECTION Ds4CachedOutputReportUpdateLock;
+    BOOLEAN IsDisposing;
+} VIGEM_TARGET;
+
+#define DEVICE_IO_CONTROL_BEGIN	\
+	DWORD transferred = 0; \
+	OVERLAPPED lOverlapped = { 0 }; \
+	lOverlapped.hEvent = CreateEvent(NULL, FALSE, FALSE, NULL)
+
+#define DEVICE_IO_CONTROL_END \
+	if (lOverlapped.hEvent) \
+		CloseHandle(lOverlapped.hEvent)

--- a/third_party/ViGEmClient-b66d02d/src/UniUtil.h
+++ b/third_party/ViGEmClient-b66d02d/src/UniUtil.h
@@ -1,0 +1,19 @@
+#pragma once
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING 1
+#include <locale>  // wstring_convert
+
+std::string ConvertWideToANSI(const std::wstring& wstr)
+{
+    int count = WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), (int)wstr.length(), NULL, 0, NULL, NULL);
+    std::string str(count, 0);
+    WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, &str[0], count, NULL, NULL);
+    return str;
+}
+
+std::wstring ConvertAnsiToWide(const std::string& str)
+{
+    int count = MultiByteToWideChar(CP_ACP, 0, str.c_str(), (int)str.length(), NULL, 0);
+    std::wstring wstr(count, 0);
+    MultiByteToWideChar(CP_ACP, 0, str.c_str(), (int)str.length(), &wstr[0], count);
+    return wstr;
+}

--- a/third_party/ViGEmClient-b66d02d/src/ViGEmClient.cpp
+++ b/third_party/ViGEmClient-b66d02d/src/ViGEmClient.cpp
@@ -1,0 +1,1385 @@
+/*
+MIT License
+
+Copyright (c) 2017-2023 Nefarius Software Solutions e.U. and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+
+//
+// WinAPI
+// 
+#include <Windows.h>
+#include <SetupAPI.h>
+#include <initguid.h>
+#include <strsafe.h>
+
+//
+// Driver shared
+// 
+#include "ViGEm/km/BusShared.h"
+#include "ViGEm/Client.h"
+#include <winioctl.h>
+
+//
+// STL
+// 
+#include <cstdlib>
+#include <climits>
+#include <thread>
+#include <functional>
+#include <string>
+#include <iostream>
+
+//
+// Internal
+// 
+#include "Internal.h"
+#include "UniUtil.h"
+
+//#define VIGEM_VERBOSE_LOGGING_ENABLED
+
+#ifndef ERROR_INVALID_DEVICE_OBJECT_PARAMETER
+#define ERROR_INVALID_DEVICE_OBJECT_PARAMETER 0x0000028A
+#endif
+
+
+#pragma region Diagnostics
+
+#ifdef _DEBUG
+#define DBGPRINT(kwszDebugFormatString, ...) _DBGPRINT(ConvertAnsiToWide(__func__).c_str(), __LINE__, kwszDebugFormatString, __VA_ARGS__)
+#else
+#define DBGPRINT( kwszDebugFormatString, ... ) ;;
+#endif
+
+VOID _DBGPRINT(LPCWSTR kwszFunction, INT iLineNumber, LPCWSTR kwszDebugFormatString, ...)
+{
+#if defined(VIGEM_VERBOSE_LOGGING_ENABLED)
+	INT cbFormatString = 0;
+	va_list args;
+	PWCHAR wszDebugString = nullptr;
+	size_t st_Offset = 0;
+
+	va_start(args, kwszDebugFormatString);
+
+	// Get size of message string from formatting args
+	cbFormatString = _scwprintf(L"[%s:%d] ", kwszFunction, iLineNumber) * sizeof(WCHAR);
+	cbFormatString += _vscwprintf(kwszDebugFormatString, args) * sizeof(WCHAR);
+	cbFormatString += sizeof(WCHAR); // for null-terminator
+
+	// Allocate message string
+	wszDebugString = static_cast<PWCHAR>(malloc(cbFormatString));
+	if (wszDebugString == nullptr)
+		return;
+
+	// Populate the buffer with the contents of the format string
+	StringCbPrintfW(wszDebugString, cbFormatString, L"[%s:%d] ", kwszFunction, iLineNumber);
+	StringCbLengthW(wszDebugString, cbFormatString, &st_Offset);
+	StringCbVPrintfW(&wszDebugString[st_Offset / sizeof(WCHAR)], cbFormatString - st_Offset, kwszDebugFormatString,
+		args);
+
+	// Ensure null-terminated
+	wszDebugString[cbFormatString - 1] = L'\0';
+
+	// Output message
+	OutputDebugStringW(wszDebugString);
+	OutputDebugStringW(L"\n");
+
+	free(wszDebugString);
+	va_end(args);
+#else
+	std::ignore = kwszFunction;
+	std::ignore = iLineNumber;
+	std::ignore = kwszDebugFormatString;
+#endif
+}
+
+static void to_hex(unsigned char* in, size_t insz, char* out, size_t outsz)
+{
+	unsigned char* pin = in;
+	auto hex = "0123456789ABCDEF";
+	char* pout = out;
+	for (; pin < in + insz; pout += 3, pin++)
+	{
+		pout[0] = hex[(*pin >> 4) & 0xF];
+		pout[1] = hex[*pin & 0xF];
+		pout[2] = ':';
+		if ((size_t)(pout + 3 - out) > outsz)
+		{
+			/* Better to truncate output string than overflow buffer */
+			/* it would be still better to either return a status */
+			/* or ensure the target buffer is large enough and it never happen */
+			break;
+		}
+	}
+	pout[-1] = 0;
+}
+
+#pragma endregion
+
+
+//
+// Initializes a virtual gamepad object.
+// 
+PVIGEM_TARGET FORCEINLINE VIGEM_TARGET_ALLOC_INIT(
+	_In_ VIGEM_TARGET_TYPE Type
+)
+{
+	auto target = static_cast<PVIGEM_TARGET>(malloc(sizeof(VIGEM_TARGET)));
+
+	if (!target)
+		return nullptr;
+
+	memset(target, 0, sizeof(VIGEM_TARGET));
+
+	target->Size = sizeof(VIGEM_TARGET);
+	target->State = VIGEM_TARGET_INITIALIZED;
+	target->Type = Type;
+	return target;
+}
+
+static DWORD WINAPI vigem_internal_ds4_output_report_pickup_handler(LPVOID Parameter)
+{
+	const auto pClient = static_cast<PVIGEM_CLIENT>(Parameter);
+	DS4_AWAIT_OUTPUT await;
+	DEVICE_IO_CONTROL_BEGIN;
+
+	// Abort event first so that in the case both are signaled at once, the result will be for the abort event
+	const HANDLE waitEvents[] =
+	{
+		pClient->hDS4OutputReportPickupThreadAbortEvent,
+		lOverlapped.hEvent
+	};
+
+	DBGPRINT(L"Started DS4 Output Report pickup thread for 0x%p", pClient);
+
+	do
+	{
+		DS4_AWAIT_OUTPUT_INIT(&await, 0);
+
+		DeviceIoControl(
+			pClient->hBusDevice,
+			IOCTL_DS4_AWAIT_OUTPUT_AVAILABLE,
+			&await,
+			await.Size,
+			&await,
+			await.Size,
+			&transferred,
+			&lOverlapped
+		);
+
+		const DWORD waitResult = WaitForMultipleObjects(
+			static_cast<DWORD>(std::size(waitEvents)),
+			waitEvents,
+			FALSE,
+			INFINITE
+		);
+
+		if (waitResult == WAIT_OBJECT_0)
+		{
+			DBGPRINT(L"Abort event signalled during read, exiting thread", NULL);
+			CancelIoEx(pClient->hBusDevice, &lOverlapped);
+			break;
+		}
+
+		if (waitResult == WAIT_FAILED)
+		{
+			const DWORD error = GetLastError();
+			DBGPRINT(L"Win32 error from multi-object wait: 0x%X", error);
+			continue;
+		}
+
+		if (waitResult != WAIT_OBJECT_0 + 1)
+		{
+			DBGPRINT(L"Unexpected result from multi-object wait: 0x%X", waitResult);
+		}
+
+		if (GetOverlappedResult(pClient->hBusDevice, &lOverlapped, &transferred, FALSE) == FALSE)
+		{
+			const DWORD error = GetLastError();
+
+			//
+			// Backwards compatibility with version pre-1.19, where this IOCTL doesn't exist
+			// 
+			if (error == ERROR_INVALID_PARAMETER)
+			{
+				DBGPRINT(L"Currently used driver version doesn't support this request, aborting", NULL);
+				break;
+			}
+
+			if (error == ERROR_OPERATION_ABORTED)
+			{
+				DBGPRINT(L"Read has been cancelled, aborting", NULL);
+				break;
+			}
+
+			if (error == ERROR_IO_INCOMPLETE)
+			{
+				DBGPRINT(L"Pending I/O not completed, aborting", NULL);
+				CancelIoEx(pClient->hBusDevice, &lOverlapped);
+				break;
+			}
+
+			DBGPRINT(L"Win32 error from overlapped result: 0x%X", error);
+			continue;
+		}
+
+#if defined(VIGEM_VERBOSE_LOGGING_ENABLED)
+		DBGPRINT(L"Dumping buffer for %d", await.SerialNo);
+
+		const PCHAR dumpBuffer = (PCHAR)calloc(sizeof(DS4_OUTPUT_BUFFER), 3);
+		if (dumpBuffer != nullptr)
+		{
+			to_hex(await.Report.Buffer, sizeof(DS4_OUTPUT_BUFFER), dumpBuffer, sizeof(DS4_OUTPUT_BUFFER) * 3);
+			OutputDebugStringA(dumpBuffer);
+			free(dumpBuffer);
+		}
+#endif
+
+		const PVIGEM_TARGET pTarget = pClient->pTargetsList[await.SerialNo];
+
+		if (pTarget && !pTarget->IsDisposing && pTarget->Type == DualShock4Wired)
+		{
+			memcpy(&pTarget->Ds4CachedOutputReport, &await.Report, sizeof(DS4_OUTPUT_BUFFER));
+			SetEvent(pTarget->Ds4CachedOutputReportUpdateAvailable);
+		}
+		else
+		{
+			DBGPRINT(L"No target to report to for serial %d", await.SerialNo);
+		}
+	} while (TRUE);
+
+	DEVICE_IO_CONTROL_END;
+
+	DBGPRINT(L"Finished DS4 Output Report pickup thread for 0x%p", pClient);
+
+	return 0;
+}
+
+PVIGEM_CLIENT vigem_alloc()
+{
+	const auto driver = static_cast<PVIGEM_CLIENT>(malloc(sizeof(VIGEM_CLIENT)));
+
+	if (!driver)
+		return nullptr;
+
+	RtlZeroMemory(driver, sizeof(VIGEM_CLIENT));
+
+	driver->hBusDevice = INVALID_HANDLE_VALUE;
+	driver->hDS4OutputReportPickupThreadAbortEvent = CreateEvent(
+		nullptr,
+		TRUE,
+		FALSE,
+		nullptr
+	);
+
+	return driver;
+}
+
+void vigem_free(PVIGEM_CLIENT vigem)
+{
+	if (vigem)
+	{
+		CloseHandle(vigem->hDS4OutputReportPickupThreadAbortEvent);
+
+		free(vigem);
+	}
+}
+
+VIGEM_ERROR vigem_connect(PVIGEM_CLIENT vigem)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	SP_DEVICE_INTERFACE_DATA deviceInterfaceData = { 0 };
+	deviceInterfaceData.cbSize = sizeof(deviceInterfaceData);
+	DWORD memberIndex = 0;
+	DWORD requiredSize = 0;
+	auto error = VIGEM_ERROR_BUS_NOT_FOUND;
+
+	// check for already open handle as re-opening accidentally would destroy all live targets
+	if (vigem->hBusDevice != INVALID_HANDLE_VALUE)
+	{
+		return VIGEM_ERROR_BUS_ALREADY_CONNECTED;
+	}
+
+	const auto deviceInfoSet = SetupDiGetClassDevs(
+		&GUID_DEVINTERFACE_BUSENUM_VIGEM,
+		nullptr,
+		nullptr,
+		DIGCF_PRESENT | DIGCF_DEVICEINTERFACE
+	);
+
+	// enumerate device instances
+	while (SetupDiEnumDeviceInterfaces(
+		deviceInfoSet,
+		nullptr,
+		&GUID_DEVINTERFACE_BUSENUM_VIGEM,
+		memberIndex++,
+		&deviceInterfaceData
+	))
+	{
+		// get required target buffer size
+		SetupDiGetDeviceInterfaceDetail(deviceInfoSet, &deviceInterfaceData, nullptr, 0, &requiredSize, nullptr);
+
+		// allocate target buffer
+		const auto detailDataBuffer = static_cast<PSP_DEVICE_INTERFACE_DETAIL_DATA>(malloc(requiredSize));
+		detailDataBuffer->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+
+		// get detail buffer
+		if (!SetupDiGetDeviceInterfaceDetail(
+			deviceInfoSet,
+			&deviceInterfaceData,
+			detailDataBuffer,
+			requiredSize,
+			&requiredSize,
+			nullptr
+		))
+		{
+			free(detailDataBuffer);
+			error = VIGEM_ERROR_BUS_NOT_FOUND;
+			continue;
+		}
+
+		// bus found, open it
+		vigem->hBusDevice = CreateFile(
+			detailDataBuffer->DevicePath,
+			GENERIC_READ | GENERIC_WRITE,
+			FILE_SHARE_READ | FILE_SHARE_WRITE,
+			nullptr,
+			OPEN_EXISTING,
+			FILE_ATTRIBUTE_NORMAL | FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH | FILE_FLAG_OVERLAPPED,
+			nullptr
+		);
+
+		// check bus open result
+		if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		{
+			error = VIGEM_ERROR_BUS_ACCESS_FAILED;
+			free(detailDataBuffer);
+			continue;
+		}
+
+		DWORD transferred = 0;
+		OVERLAPPED lOverlapped = { 0 };
+		lOverlapped.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+		VIGEM_CHECK_VERSION version;
+		VIGEM_CHECK_VERSION_INIT(&version, VIGEM_COMMON_VERSION);
+
+		// send compiled library version to driver to check compatibility
+		DeviceIoControl(
+			vigem->hBusDevice,
+			IOCTL_VIGEM_CHECK_VERSION,
+			&version,
+			version.Size,
+			nullptr,
+			0,
+			&transferred,
+			&lOverlapped
+		);
+
+		// wait for result
+		if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) != 0)
+		{
+			vigem->hDS4OutputReportPickupThread = CreateThread(
+				nullptr,
+				0,
+				vigem_internal_ds4_output_report_pickup_handler,
+				vigem,
+				0,
+				nullptr
+			);
+
+			error = VIGEM_ERROR_NONE;
+			free(detailDataBuffer);
+			CloseHandle(lOverlapped.hEvent);
+			break;
+		}
+
+		error = VIGEM_ERROR_BUS_VERSION_MISMATCH;
+
+		CloseHandle(lOverlapped.hEvent);
+		free(detailDataBuffer);
+	}
+
+	SetupDiDestroyDeviceInfoList(deviceInfoSet);
+
+	return error;
+}
+
+void vigem_disconnect(PVIGEM_CLIENT vigem)
+{
+	if (!vigem)
+		return;
+
+	if (vigem->hDS4OutputReportPickupThread && vigem->hDS4OutputReportPickupThreadAbortEvent)
+	{
+		DBGPRINT(L"Awaiting DS4 thread clean-up for 0x%p", vigem);
+
+		SetEvent(vigem->hDS4OutputReportPickupThreadAbortEvent);
+		WaitForSingleObject(vigem->hDS4OutputReportPickupThread, INFINITE);
+		CloseHandle(vigem->hDS4OutputReportPickupThread);
+
+		DBGPRINT(L"DS4 thread clean-up for 0x%p finished", vigem);
+	}
+
+	if (vigem->hBusDevice != INVALID_HANDLE_VALUE)
+	{
+		DBGPRINT(L"Closing bus handle for 0x%p", vigem);
+
+		CloseHandle(vigem->hBusDevice);
+		vigem->hBusDevice = INVALID_HANDLE_VALUE;
+	}
+
+	RtlZeroMemory(vigem, sizeof(VIGEM_CLIENT));
+}
+
+BOOLEAN vigem_target_is_waitable_add_supported(PVIGEM_TARGET target)
+{
+	//
+	// Safety check to make people use the older functions and not cause issues
+	// Should never pass in an invalid target but doesn't hurt to check.
+	//
+	if (!target)
+		return FALSE;
+
+	// TODO: Replace all this with a more robust version check system
+	return !target->IsWaitReadyUnsupported;
+}
+
+PVIGEM_TARGET vigem_target_x360_alloc(void)
+{
+	const auto target = VIGEM_TARGET_ALLOC_INIT(Xbox360Wired);
+
+	if (!target)
+		return nullptr;
+
+	target->VendorId = 0x045E;
+	target->ProductId = 0x028E;
+
+	return target;
+}
+
+PVIGEM_TARGET vigem_target_ds4_alloc(void)
+{
+	const auto target = VIGEM_TARGET_ALLOC_INIT(DualShock4Wired);
+
+	if (!target)
+		return nullptr;
+
+	target->VendorId = 0x054C;
+	target->ProductId = 0x05C4;
+	target->Ds4CachedOutputReportUpdateAvailable = CreateEvent(
+		nullptr,
+		FALSE,
+		FALSE,
+		nullptr
+	);
+	InitializeCriticalSection(&target->Ds4CachedOutputReportUpdateLock);
+
+	return target;
+}
+
+void vigem_target_free(PVIGEM_TARGET target)
+{
+	if (target)
+	{
+		if (target->Ds4CachedOutputReportUpdateAvailable)
+		{
+			CloseHandle(target->Ds4CachedOutputReportUpdateAvailable);
+		}
+
+		DeleteCriticalSection(&target->Ds4CachedOutputReportUpdateLock);
+
+		free(target);
+	}
+}
+
+VIGEM_ERROR vigem_target_add(PVIGEM_CLIENT vigem, PVIGEM_TARGET target)
+{
+	VIGEM_ERROR error = VIGEM_ERROR_NO_FREE_SLOT;
+	DWORD transferred = 0;
+	VIGEM_PLUGIN_TARGET plugin;
+	VIGEM_WAIT_DEVICE_READY devReady;
+	OVERLAPPED olPlugIn = { 0 };
+	olPlugIn.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+	OVERLAPPED olWait = { 0 };
+	olWait.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+	do
+	{
+		if (!vigem)
+		{
+			error = VIGEM_ERROR_BUS_INVALID_HANDLE;
+			break;
+		}
+
+		if (!target)
+		{
+			error = VIGEM_ERROR_INVALID_TARGET;
+			break;
+		}
+
+		if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		{
+			error = VIGEM_ERROR_BUS_NOT_FOUND;
+			break;
+		}
+
+		if (target->State == VIGEM_TARGET_NEW)
+		{
+			error = VIGEM_ERROR_TARGET_UNINITIALIZED;
+			break;
+		}
+
+		if (target->State == VIGEM_TARGET_CONNECTED)
+		{
+			error = VIGEM_ERROR_ALREADY_CONNECTED;
+			break;
+		}
+
+		//
+		// TODO: this is mad stupid, redesign, so that the bus fills the assigned slot
+		// 
+		for (target->SerialNo = 1; target->SerialNo <= VIGEM_TARGETS_MAX; target->SerialNo++)
+		{
+			VIGEM_PLUGIN_TARGET_INIT(&plugin, target->SerialNo, target->Type);
+
+			plugin.VendorId = target->VendorId;
+			plugin.ProductId = target->ProductId;
+
+			/*
+			 * Request plugin of device. This is an inherently asynchronous operation,
+			 * which is addressed differently through the history of the driver design.
+			 * Pre-v1.17 this request was kept pending until the child was deemed operational
+			 * which unfortunately causes synchronization issues on some systems.
+			 * Starting with v1.17 "waiting" for full power-up is done with an additional
+			 * IOCTL that is sent immediately after and kept pending until the driver
+			 * reports that the device can receive report updates. The following section
+			 * and error handling is designed to achieve transparent backwards compatibility
+			 * to not break applications using the pre-v1.17 client SDK. This is not a 100%
+			 * perfect and can cause other functions to fail if called too soon but
+			 * hopefully the applications will just ignore these errors and retry ;)
+			 */
+			DeviceIoControl(
+				vigem->hBusDevice,
+				IOCTL_VIGEM_PLUGIN_TARGET,
+				&plugin,
+				plugin.Size,
+				nullptr,
+				0,
+				&transferred,
+				&olPlugIn
+			);
+
+			//
+			// This should return fairly immediately >=v1.17
+			// 
+			if (GetOverlappedResult(vigem->hBusDevice, &olPlugIn, &transferred, TRUE) != 0)
+			{
+				/*
+				 * This function is announced to be blocking/synchronous, a concept that
+				 * doesn't reflect the way the bus driver/PNP manager bring child devices
+				 * to life. Therefore, we send another IOCTL which will be kept pending
+				 * until the bus driver has been notified that the child device has
+				 * reached a state that is deemed operational. This request is only
+				 * supported on drivers v1.17 or higher, so gracefully cause errors
+				 * of this call as a potential success and keep the device plugged in.
+				 */
+				VIGEM_WAIT_DEVICE_READY_INIT(&devReady, plugin.SerialNo);
+
+				DeviceIoControl(
+					vigem->hBusDevice,
+					IOCTL_VIGEM_WAIT_DEVICE_READY,
+					&devReady,
+					devReady.Size,
+					nullptr,
+					0,
+					&transferred,
+					&olWait
+				);
+
+				if (GetOverlappedResult(vigem->hBusDevice, &olWait, &transferred, TRUE) != 0)
+				{
+					target->State = VIGEM_TARGET_CONNECTED;
+
+					error = VIGEM_ERROR_NONE;
+					break;
+				}
+
+				//
+				// Backwards compatibility with version pre-1.17, where this IOCTL doesn't exist
+				// 
+				if (GetLastError() == ERROR_INVALID_PARAMETER)
+				{
+					target->State = VIGEM_TARGET_CONNECTED;
+					target->IsWaitReadyUnsupported = true;
+
+					error = VIGEM_ERROR_NONE;
+					break;
+				}
+
+				//
+				// Don't leave device connected if the wait call failed
+				// 
+				error = vigem_target_remove(vigem, target);
+				break;
+			}
+		}
+	} while (false);
+
+	if (VIGEM_SUCCESS(error))
+	{
+		vigem->pTargetsList[target->SerialNo] = target;
+	}
+
+	if (olPlugIn.hEvent)
+		CloseHandle(olPlugIn.hEvent);
+
+	if (olWait.hEvent)
+		CloseHandle(olWait.hEvent);
+
+	return error;
+}
+
+VIGEM_ERROR vigem_target_add_async(PVIGEM_CLIENT vigem, PVIGEM_TARGET target, PFN_VIGEM_TARGET_ADD_RESULT result)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->State == VIGEM_TARGET_NEW)
+		return VIGEM_ERROR_TARGET_UNINITIALIZED;
+
+	if (target->State == VIGEM_TARGET_CONNECTED)
+		return VIGEM_ERROR_ALREADY_CONNECTED;
+
+	std::thread _async{
+		[](
+		PVIGEM_TARGET _Target,
+		PVIGEM_CLIENT _Client,
+		PFN_VIGEM_TARGET_ADD_RESULT _Result)
+		{
+			const auto error = vigem_target_add(_Client, _Target);
+
+			_Result(_Client, _Target, error);
+		},
+		target, vigem, result
+	};
+
+	_async.detach();
+
+	return VIGEM_ERROR_NONE;
+}
+
+VIGEM_ERROR vigem_target_remove(PVIGEM_CLIENT vigem, PVIGEM_TARGET target)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->State == VIGEM_TARGET_NEW)
+		return VIGEM_ERROR_TARGET_UNINITIALIZED;
+
+	if (target->State != VIGEM_TARGET_CONNECTED)
+		return VIGEM_ERROR_TARGET_NOT_PLUGGED_IN;
+
+	VIGEM_UNPLUG_TARGET unplug;
+	DEVICE_IO_CONTROL_BEGIN;
+
+	VIGEM_UNPLUG_TARGET_INIT(&unplug, target->SerialNo);
+
+	DeviceIoControl(
+		vigem->hBusDevice,
+		IOCTL_VIGEM_UNPLUG_TARGET,
+		&unplug,
+		unplug.Size,
+		nullptr,
+		0,
+		&transferred,
+		&lOverlapped
+	);
+
+	if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) != 0)
+	{
+		if (target->Type == DualShock4Wired)
+		{
+			EnterCriticalSection(&target->Ds4CachedOutputReportUpdateLock);
+			{
+				target->IsDisposing = TRUE;
+				vigem->pTargetsList[target->SerialNo] = nullptr;
+
+			}
+			LeaveCriticalSection(&target->Ds4CachedOutputReportUpdateLock);
+		}
+
+		target->State = VIGEM_TARGET_DISCONNECTED;
+
+		DEVICE_IO_CONTROL_END;
+
+		return VIGEM_ERROR_NONE;
+	}
+
+	DEVICE_IO_CONTROL_END;
+
+	return VIGEM_ERROR_REMOVAL_FAILED;
+}
+
+VIGEM_ERROR vigem_target_x360_register_notification(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	PFN_VIGEM_X360_NOTIFICATION notification,
+	LPVOID userData
+)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->SerialNo == 0 || notification == nullptr)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (target->Notification == reinterpret_cast<FARPROC>(notification))
+		return VIGEM_ERROR_CALLBACK_ALREADY_REGISTERED;
+
+	target->Notification = reinterpret_cast<FARPROC>(notification);
+	target->NotificationUserData = userData;
+
+	if (target->CancelNotificationThreadEvent == nullptr)
+		target->CancelNotificationThreadEvent = CreateEvent(
+			nullptr,
+			TRUE,
+			FALSE,
+			nullptr
+		);
+	else
+		ResetEvent(target->CancelNotificationThreadEvent);
+
+	std::thread _async{
+		[](
+		PVIGEM_TARGET _Target,
+		PVIGEM_CLIENT _Client,
+		LPVOID _UserData)
+		{
+			DEVICE_IO_CONTROL_BEGIN;
+
+			XUSB_REQUEST_NOTIFICATION xrn;
+			XUSB_REQUEST_NOTIFICATION_INIT(&xrn, _Target->SerialNo);
+
+			do
+			{
+				DeviceIoControl(
+					_Client->hBusDevice,
+					IOCTL_XUSB_REQUEST_NOTIFICATION,
+					&xrn,
+					xrn.Size,
+					&xrn,
+					xrn.Size,
+					&transferred,
+					&lOverlapped
+				);
+
+				if (GetOverlappedResult(_Client->hBusDevice, &lOverlapped, &transferred, TRUE) != 0)
+				{
+					if (_Target->Notification == nullptr)
+					{
+						DEVICE_IO_CONTROL_END;
+						return;
+					}
+
+					reinterpret_cast<PFN_VIGEM_X360_NOTIFICATION>(_Target->Notification)(
+						_Client, _Target, xrn.LargeMotor, xrn.SmallMotor, xrn.LedNumber, _UserData
+					);
+
+					continue;
+				}
+
+				if (GetLastError() == ERROR_ACCESS_DENIED || GetLastError() == ERROR_OPERATION_ABORTED)
+				{
+					DEVICE_IO_CONTROL_END;
+					return;
+				}
+			} while (TRUE);
+		},
+		target, vigem, userData
+	};
+
+	_async.detach();
+
+	return VIGEM_ERROR_NONE;
+}
+
+VIGEM_ERROR vigem_target_ds4_register_notification(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	PFN_VIGEM_DS4_NOTIFICATION notification,
+	LPVOID userData
+)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->SerialNo == 0 || notification == nullptr)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (target->Notification == reinterpret_cast<FARPROC>(notification))
+		return VIGEM_ERROR_CALLBACK_ALREADY_REGISTERED;
+
+	target->Notification = reinterpret_cast<FARPROC>(notification);
+	target->NotificationUserData = userData;
+
+	if (target->CancelNotificationThreadEvent == nullptr)
+		target->CancelNotificationThreadEvent = CreateEvent(
+			nullptr,
+			TRUE,
+			FALSE,
+			nullptr
+		);
+	else
+		ResetEvent(target->CancelNotificationThreadEvent);
+
+	std::thread _async{
+		[](
+		PVIGEM_TARGET _Target,
+		PVIGEM_CLIENT _Client,
+		LPVOID _UserData)
+		{
+			DEVICE_IO_CONTROL_BEGIN;
+
+			DS4_REQUEST_NOTIFICATION ds4rn;
+			DS4_REQUEST_NOTIFICATION_INIT(&ds4rn, _Target->SerialNo);
+
+			do
+			{
+				DeviceIoControl(
+					_Client->hBusDevice,
+					IOCTL_DS4_REQUEST_NOTIFICATION,
+					&ds4rn,
+					ds4rn.Size,
+					&ds4rn,
+					ds4rn.Size,
+					&transferred,
+					&lOverlapped
+				);
+
+				if (GetOverlappedResult(_Client->hBusDevice, &lOverlapped, &transferred, TRUE) != 0)
+				{
+					if (_Target->Notification == nullptr)
+					{
+						DEVICE_IO_CONTROL_END;
+						return;
+					}
+
+					reinterpret_cast<PFN_VIGEM_DS4_NOTIFICATION>(_Target->Notification)(
+						_Client, _Target, ds4rn.Report.LargeMotor,
+						ds4rn.Report.SmallMotor,
+						ds4rn.Report.LightbarColor, _UserData
+					);
+
+					continue;
+				}
+
+				if (GetLastError() == ERROR_ACCESS_DENIED || GetLastError() == ERROR_OPERATION_ABORTED)
+				{
+					DEVICE_IO_CONTROL_END;
+					return;
+				}
+			} while (TRUE);
+		},
+		target, vigem, userData
+	};
+
+	_async.detach();
+
+	return VIGEM_ERROR_NONE;
+}
+
+void vigem_target_x360_unregister_notification(PVIGEM_TARGET target)
+{
+	if (target->CancelNotificationThreadEvent != nullptr)
+		SetEvent(target->CancelNotificationThreadEvent);
+
+	if (target->CancelNotificationThreadEvent != nullptr)
+	{
+		CloseHandle(target->CancelNotificationThreadEvent);
+		target->CancelNotificationThreadEvent = nullptr;
+	}
+
+	target->Notification = nullptr;
+	target->NotificationUserData = nullptr;
+}
+
+void vigem_target_ds4_unregister_notification(PVIGEM_TARGET target)
+{
+	vigem_target_x360_unregister_notification(target); // The same x360_unregister handler works for DS4_unregister also
+}
+
+void vigem_target_set_vid(PVIGEM_TARGET target, USHORT vid)
+{
+	target->VendorId = vid;
+}
+
+void vigem_target_set_pid(PVIGEM_TARGET target, USHORT pid)
+{
+	target->ProductId = pid;
+}
+
+USHORT vigem_target_get_vid(PVIGEM_TARGET target)
+{
+	return target->VendorId;
+}
+
+USHORT vigem_target_get_pid(PVIGEM_TARGET target)
+{
+	return target->ProductId;
+}
+
+VIGEM_ERROR vigem_target_x360_update(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	XUSB_REPORT report
+)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->SerialNo == 0)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	DEVICE_IO_CONTROL_BEGIN;
+
+	XUSB_SUBMIT_REPORT xsr;
+	XUSB_SUBMIT_REPORT_INIT(&xsr, target->SerialNo);
+
+	xsr.Report = report;
+
+	DeviceIoControl(
+		vigem->hBusDevice,
+		IOCTL_XUSB_SUBMIT_REPORT,
+		&xsr,
+		xsr.Size,
+		nullptr,
+		0,
+		&transferred,
+		&lOverlapped
+	);
+
+	if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+	{
+		if (GetLastError() == ERROR_ACCESS_DENIED)
+		{
+			DEVICE_IO_CONTROL_END;
+			return VIGEM_ERROR_INVALID_TARGET;
+		}
+	}
+
+	DEVICE_IO_CONTROL_END;
+
+	return VIGEM_ERROR_NONE;
+}
+
+VIGEM_ERROR vigem_target_ds4_update(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	DS4_REPORT report
+)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->SerialNo == 0)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	DEVICE_IO_CONTROL_BEGIN;
+
+	DS4_SUBMIT_REPORT dsr;
+	DS4_SUBMIT_REPORT_INIT(&dsr, target->SerialNo);
+
+	dsr.Report = report;
+
+	DeviceIoControl(
+		vigem->hBusDevice,
+		IOCTL_DS4_SUBMIT_REPORT,
+		&dsr,
+		dsr.Size,
+		nullptr,
+		0,
+		&transferred,
+		&lOverlapped
+	);
+
+	if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+	{
+		if (GetLastError() == ERROR_ACCESS_DENIED)
+		{
+			DEVICE_IO_CONTROL_END;
+			return VIGEM_ERROR_INVALID_TARGET;
+		}
+	}
+
+	DEVICE_IO_CONTROL_END;
+
+	return VIGEM_ERROR_NONE;
+}
+
+VIGEM_ERROR vigem_target_ds4_update_ex(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	DS4_REPORT_EX report
+)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->SerialNo == 0)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	DEVICE_IO_CONTROL_BEGIN;
+
+	DS4_SUBMIT_REPORT_EX dsr;
+	DS4_SUBMIT_REPORT_EX_INIT(&dsr, target->SerialNo);
+
+	dsr.Report = report;
+
+	DeviceIoControl(
+		vigem->hBusDevice,
+		IOCTL_DS4_SUBMIT_REPORT, // Same IOCTL, just different size
+		&dsr,
+		dsr.Size,
+		nullptr,
+		0,
+		&transferred,
+		&lOverlapped
+	);
+
+	if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+	{
+		if (GetLastError() == ERROR_ACCESS_DENIED)
+		{
+			DEVICE_IO_CONTROL_END;
+			return VIGEM_ERROR_INVALID_TARGET;
+		}
+
+		/*
+		 * NOTE: this will not happen on v1.16 due to NTSTATUS accidentally been set
+		 * as STATUS_SUCCESS when the submitted buffer size wasn't the expected one.
+		 * For backwards compatibility this function will silently fail (not cause
+		 * report updates) when run with the v1.16 driver. This API was introduced
+		 * with v1.17 so it won't affect existing applications built before.
+		 */
+		if (GetLastError() == ERROR_INVALID_PARAMETER)
+		{
+			DEVICE_IO_CONTROL_END;
+			return VIGEM_ERROR_NOT_SUPPORTED;
+		}
+	}
+
+	DEVICE_IO_CONTROL_END;
+
+	return VIGEM_ERROR_NONE;
+}
+
+ULONG vigem_target_get_index(PVIGEM_TARGET target)
+{
+	return target->SerialNo;
+}
+
+VIGEM_TARGET_TYPE vigem_target_get_type(PVIGEM_TARGET target)
+{
+	return target->Type;
+}
+
+BOOL vigem_target_is_attached(PVIGEM_TARGET target)
+{
+	return (target->State == VIGEM_TARGET_CONNECTED);
+}
+
+VIGEM_ERROR vigem_target_x360_get_user_index(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	PULONG index
+)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->SerialNo == 0 || target->Type != Xbox360Wired)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (!index)
+		return VIGEM_ERROR_INVALID_PARAMETER;
+
+	DEVICE_IO_CONTROL_BEGIN;
+
+	XUSB_GET_USER_INDEX gui;
+	XUSB_GET_USER_INDEX_INIT(&gui, target->SerialNo);
+
+	DeviceIoControl(
+		vigem->hBusDevice,
+		IOCTL_XUSB_GET_USER_INDEX,
+		&gui,
+		gui.Size,
+		&gui,
+		gui.Size,
+		&transferred,
+		&lOverlapped
+	);
+
+	if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+	{
+		const auto error = GetLastError();
+
+		if (error == ERROR_ACCESS_DENIED)
+		{
+			DEVICE_IO_CONTROL_END;
+			return VIGEM_ERROR_INVALID_TARGET;
+		}
+
+		if (error == ERROR_INVALID_DEVICE_OBJECT_PARAMETER)
+		{
+			DEVICE_IO_CONTROL_END;
+			return VIGEM_ERROR_XUSB_USERINDEX_OUT_OF_RANGE;
+		}
+	}
+
+	DEVICE_IO_CONTROL_END;
+
+	*index = gui.UserIndex;
+
+	return VIGEM_ERROR_NONE;
+}
+
+VIGEM_ERROR vigem_target_ds4_await_output_report(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	PDS4_OUTPUT_BUFFER buffer
+)
+{
+	return vigem_target_ds4_await_output_report_timeout(vigem, target, INFINITE, buffer);
+}
+
+VIGEM_ERROR vigem_target_ds4_await_output_report_timeout(
+	PVIGEM_CLIENT vigem,
+	PVIGEM_TARGET target,
+	DWORD milliseconds,
+	PDS4_OUTPUT_BUFFER buffer
+)
+{
+	if (!vigem)
+		return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+	if (!target)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+		return VIGEM_ERROR_BUS_NOT_FOUND;
+
+	if (target->SerialNo == 0 || target->Type != DualShock4Wired)
+		return VIGEM_ERROR_INVALID_TARGET;
+
+	if (!buffer)
+		return VIGEM_ERROR_INVALID_PARAMETER;
+
+	VIGEM_ERROR error = VIGEM_ERROR_NONE;
+
+	EnterCriticalSection(&target->Ds4CachedOutputReportUpdateLock);
+	{
+		if (!target->IsDisposing)
+		{
+			const DWORD status = WaitForSingleObject(target->Ds4CachedOutputReportUpdateAvailable, milliseconds);
+
+			if (status == WAIT_TIMEOUT)
+			{
+				error = VIGEM_ERROR_TIMED_OUT;
+			}
+			else
+			{
+#if defined(VIGEM_VERBOSE_LOGGING_ENABLED)
+				DBGPRINT(L"Dumping buffer for %d", target->SerialNo);
+
+				const PCHAR dumpBuffer = (PCHAR)calloc(sizeof(DS4_OUTPUT_BUFFER), 3);
+				to_hex(target->Ds4CachedOutputReport.Buffer, sizeof(DS4_OUTPUT_BUFFER), dumpBuffer, sizeof(DS4_OUTPUT_BUFFER) * 3);
+				OutputDebugStringA(dumpBuffer);
+#endif
+
+				RtlCopyMemory(buffer, &target->Ds4CachedOutputReport, sizeof(DS4_OUTPUT_BUFFER));
+			}
+		}
+		else
+		{
+			error = VIGEM_ERROR_IS_DISPOSING;
+		}
+	}
+	LeaveCriticalSection(&target->Ds4CachedOutputReportUpdateLock);
+
+	return error;
+}
+
+VIGEM_ERROR vigem_target_x360_get_output(
+    PVIGEM_CLIENT vigem,
+    PVIGEM_TARGET target,
+    PXUSB_OUTPUT_DATA output
+)
+{
+    if (!vigem)
+        return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+    if (!target)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+        return VIGEM_ERROR_BUS_NOT_FOUND;
+
+    if (target->SerialNo == 0 || target->Type != Xbox360Wired)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (!output)
+        return VIGEM_ERROR_INVALID_PARAMETER;
+
+    DWORD transferred = 0;
+    OVERLAPPED lOverlapped = { 0 };
+    lOverlapped.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+    XUSB_REQUEST_NOTIFICATION xrn;
+    XUSB_REQUEST_NOTIFICATION_INIT(&xrn, target->SerialNo);
+
+    DeviceIoControl(
+        vigem->hBusDevice,
+        IOCTL_XUSB_REQUEST_NOTIFICATION,
+        &xrn,
+        xrn.Size,
+        &xrn,
+        xrn.Size,
+        &transferred,
+        &lOverlapped
+    );
+
+    if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+    {
+        return VIGEM_ERROR_INVALID_TARGET;
+    }
+
+    CloseHandle(lOverlapped.hEvent);
+
+    output->LargeMotor = xrn.LargeMotor;
+    output->SmallMotor = xrn.SmallMotor;
+    output->LedNumber = xrn.LedNumber;
+
+    return VIGEM_ERROR_NONE;
+}
+
+VIGEM_ERROR vigem_target_ds4_get_output(
+    PVIGEM_CLIENT vigem,
+    PVIGEM_TARGET target,
+    PDS4_OUTPUT_DATA output
+)
+{
+    if (!vigem)
+        return VIGEM_ERROR_BUS_INVALID_HANDLE;
+
+    if (!target)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (vigem->hBusDevice == INVALID_HANDLE_VALUE)
+        return VIGEM_ERROR_BUS_NOT_FOUND;
+
+    if (target->SerialNo == 0 || target->Type != DualShock4Wired)
+        return VIGEM_ERROR_INVALID_TARGET;
+
+    if (!output)
+        return VIGEM_ERROR_INVALID_PARAMETER;
+
+    DWORD transferred = 0;
+    OVERLAPPED lOverlapped = { 0 };
+    lOverlapped.hEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+    DS4_REQUEST_NOTIFICATION ds4rn;
+    DS4_REQUEST_NOTIFICATION_INIT(&ds4rn, target->SerialNo);
+
+    DeviceIoControl(
+        vigem->hBusDevice,
+        IOCTL_DS4_REQUEST_NOTIFICATION,
+        &ds4rn,
+        ds4rn.Size,
+        &ds4rn,
+        ds4rn.Size,
+        &transferred,
+        &lOverlapped
+    );
+
+    if (GetOverlappedResult(vigem->hBusDevice, &lOverlapped, &transferred, TRUE) == 0)
+    {
+        return VIGEM_ERROR_INVALID_TARGET;
+    }
+
+    CloseHandle(lOverlapped.hEvent);
+
+    output->LargeMotor = ds4rn.Report.LargeMotor;
+    output->SmallMotor = ds4rn.Report.SmallMotor;
+    output->LightbarColor = ds4rn.Report.LightbarColor;
+
+    return VIGEM_ERROR_NONE;
+}

--- a/third_party/ViGEmClient-b66d02d/src/resource.h
+++ b/third_party/ViGEmClient-b66d02d/src/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by ViGEmClient.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif


### PR DESCRIPTION
## Summary

- **DS4_REPORT_EX output**: PlayStation mode now sends gyro, accelerometer, touchpad contact data, and battery level on every frame via `vigem_target_ds4_update_ex()`
- **IMU forwarding**: SC gyro/accel enabled via `SETTING_IMU_MODE` when PS4 mode is active; axis-remapped to DS4 convention (SC Y↔Z swapped, Y negated); disabled automatically on teardown
- **Touchpad forwarding**: SC right pad → DS4 contact 1, SC left pad → DS4 contact 2; correct 12-bit XY packing; per-gesture contact IDs; pads claimed for mouse use are suppressed from the DS4 report
- **Battery status**: `REPORT_BATTERY_STATUS` (0x43) handled in the read loop; mapped to DS4 battery level field (0–11, 0x0B = full/done)
- **DS4 output thread**: Replaces the deprecated notification callback with a polling thread using `vigem_target_ds4_await_output_report_timeout()`
- **Enhanced haptics (both Xbox and PlayStation)**: Power curve (value^0.68), cross-channel mixing between large/small motor channels, short attack boost on rising motor edges; trackpad touch and click fire one-shot haptic pulses via `OUT_HAPTIC_PULSE` (0x81) and `OUT_HAPTIC_COMMAND` (0x82)
- **Fix**: `REPORT_SECONDARY = 0x43` renamed to `REPORT_BATTERY_STATUS`
- **ViGEMClient**: Upgraded from 1.16.18.0 to b66d02d snapshot (adds `DS4_REPORT_EX`, `vigem_target_ds4_update_ex()`, `vigem_target_ds4_await_output_report_timeout()`)

## Test plan

- [ ] Xbox mode: verify buttons, sticks, triggers, d-pad still map correctly
- [ ] Xbox mode: verify rumble fires on games that use it; check that haptic punch feels more responsive than before
- [ ] PlayStation mode: verify buttons, sticks, triggers, d-pad map correctly (A→Cross, B→Circle, X→Square, Y→Triangle)
- [ ] PlayStation mode: verify gyro is visible in a gyro-capable game or tool (e.g. Steam Input gyro overlay)
- [ ] PlayStation mode: verify right trackpad registers as DS4 touchpad contact in a game or PS4 input viewer
- [ ] PlayStation mode: verify left trackpad registers as second DS4 touchpad contact
- [ ] PlayStation mode with trackpad mouse enabled: verify the claimed pad does NOT appear as a DS4 touchpad contact while mouse mode is active
- [ ] PlayStation mode: verify battery level appears correctly in Steam or a DS4 tool
- [ ] Verify trackpad click/touch produces a haptic buzz on the SC in both Xbox and PlayStation modes
- [ ] Verify clean shutdown (no rumble left running, lizard mode restored)

## Acknowledgements

Protocol research, DS4_REPORT_EX integration approach, haptic output report IDs, and battery status report identification are based on the groundwork done by @david419kr in #18. This PR implements a targeted subset of that work with some differences in architecture and scope.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)