### PR TITLE
Validate the cycle task points at the current helper

### DIFF
--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -109,6 +109,16 @@ bool TrayApp::Init(HINSTANCE hInstance) {
     AddTrayIcon();
     UpdateTrayIcon(m_controller->IsConnected(), m_controller->IsGameModeActive(), false);
 
+    // The in-game mode needs the elevated cycle helper to take the controller
+    // back from a running Steam. Settle that here rather than on first use:
+    // the installer normally registers the task, but when it hasn't (running
+    // from a build folder, or after an uninstall) the only other trigger is
+    // the cycle itself — so the UAC prompt ambushed the user mid-game-launch.
+    // A no-op once the task exists, which is the common case. Must run after
+    // AddTrayIcon, since a declined prompt reports via the tray balloon.
+    if (m_autoMode == AutoMode::OffOnlyInGame)
+        EnsureCycleTaskRegistered();
+
     // Start watching for Steam regardless of auto mode — the state is applied
     // only when auto mode is on, and having it warm makes toggling auto mode
     // take effect instantly. The initial callback asserts the correct state

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -8,6 +8,8 @@
 #include <shellapi.h>
 #include <dbt.h>
 #include <winreg.h>
+#include <cstdio>
+#include <cstring>
 #include <string>
 
 static TrayApp* g_app = nullptr;
@@ -521,13 +523,76 @@ bool TrayApp::IsProcessElevated() {
     return ok && elev.TokenIsElevated != 0;
 }
 
+// The executable the cycle task is currently registered to run, or empty when
+// the task is missing or unreadable.
+static std::string RegisteredTaskCommand() {
+    wchar_t tempDir[MAX_PATH];
+    if (!GetTempPathW(MAX_PATH, tempDir)) return {};
+    const std::wstring xmlPath = std::wstring(tempDir) + L"SteamlessTaskQuery.xml";
+
+    // Via cmd.exe for the redirect. The XML declares encoding="UTF-16", but
+    // redirected output is single-byte — read it narrow, don't "fix" this.
+    std::wstring cmd = L"cmd.exe /c schtasks.exe /Query /TN \"";
+    cmd += CYCLE_TASK_NAME;
+    cmd += L"\" /XML > \"" + xmlPath + L"\"";
+    const bool queried = RunToolHidden(std::move(cmd));
+
+    std::string xml;
+    if (queried) {
+        if (FILE* f = nullptr; _wfopen_s(&f, xmlPath.c_str(), L"rb") == 0 && f) {
+            char buf[1024];
+            size_t n;
+            while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+                xml.append(buf, n);
+            fclose(f);
+        }
+    }
+    DeleteFileW(xmlPath.c_str());
+    if (xml.empty()) return {};
+
+    const size_t open = xml.find("<Command>");
+    if (open == std::string::npos) return {};
+    const size_t start = open + strlen("<Command>");
+    const size_t close = xml.find("</Command>", start);
+    if (close == std::string::npos) return {};
+
+    std::string cmdPath = xml.substr(start, close - start);
+    const size_t first = cmdPath.find_first_not_of(" \t\r\n");
+    const size_t last  = cmdPath.find_last_not_of(" \t\r\n");
+    if (first == std::string::npos) return {};
+    return cmdPath.substr(first, last - first + 1);
+}
+
+// True when the registered command is this build's helper. Compared against
+// both codepage renderings of our path, since which one the console redirect
+// used is not worth guessing at.
+static bool RegisteredCommandMatches(const std::string& registered,
+                                     const std::wstring& helper) {
+    if (registered.empty()) return false;
+    for (UINT cp : { CP_ACP, CP_OEMCP }) {
+        const int n = WideCharToMultiByte(cp, 0, helper.c_str(), -1,
+                                          nullptr, 0, nullptr, nullptr);
+        if (n <= 0) continue;
+        std::string narrow(static_cast<size_t>(n) - 1, '\0');
+        WideCharToMultiByte(cp, 0, helper.c_str(), -1, narrow.data(), n, nullptr, nullptr);
+        if (_stricmp(narrow.c_str(), registered.c_str()) == 0) return true;
+    }
+    return false;
+}
+
 bool TrayApp::EnsureCycleTaskRegistered() {
-    // Already registered? (The installer normally does this.)
+    // Registered AND pointing at this build's helper? Existence alone is not
+    // enough: a task left by an older or relocated install still "runs" —
+    // schtasks reports success — while executing a helper that may be gone or
+    // predate current device support, so the cycle silently does nothing and
+    // the controller is never reclaimed. That failure is invisible from the
+    // app's side, so verify the path rather than just the task.
     {
-        std::wstring query = L"schtasks.exe /Query /TN \"";
-        query += CYCLE_TASK_NAME;
-        query += L"\"";
-        if (RunToolHidden(std::move(query))) return true;
+        const std::string registered = RegisteredTaskCommand();
+        if (RegisteredCommandMatches(registered, HelperPath()))
+            return true;
+        if (!registered.empty())
+            EventLog::Write("CYCLE TASK: registered helper is stale, re-registering");
     }
 
     // One-time UAC prompt: the helper registers its own on-demand task.


### PR DESCRIPTION
## Problem

`EnsureCycleTaskRegistered()` only checked that the scheduled task **existed**, never that it pointed at the current helper.

A task left behind by an older or relocated install still runs, and `schtasks /Run` still reports success — but it executes a helper that may be gone, or that predates current device support. The cycle then does nothing, the controller is never reclaimed from Steam, and **nothing anywhere reports a failure**.

This isn't hypothetical. An uninstall left a task pointing into `C:\Program Files\...` while the app ran from a build folder. Every cycle the app ordered was a silent no-op, and from the app's side a successful `schtasks /Run` is indistinguishable from a working cycle. It cost hours of debugging.

## Fix

Query the task as XML and compare its `<Command>` against our own helper path, re-registering on mismatch and logging that it happened.

Two implementation notes worth keeping:
- The XML declares `encoding="UTF-16"`, but redirected console output is single-byte. It's read narrow deliberately — verified against real output, not assumed.
- The path is compared against both `CP_ACP` and `CP_OEMCP` renderings rather than guessing which the console redirect used. A wrong guess would mean a spurious re-register prompt.

## Also included

Registering at startup when the loaded mode is `OffOnlyInGame`, rather than waiting for a cycle to discover the problem. This is what makes the validation actionable at a reasonable moment: without it, a stale or missing task is only noticed *during* a cycle, which happens exactly when a game launches — so the UAC prompt ambushes the user mid-launch. It's a no-op when the task is present and correct, so installed users see no change.

Happy to split that back out if you'd rather ship the validation alone, but on its own the validation would still prompt at the worst possible moment.

## Not fixed (by design)

The elevation itself can't be removed — restarting a device node requires admin, and the tray app deliberately never runs elevated because an elevated foreground window blocks Steam Input's synthetic cursor via UIPI. The trigger-less `HighestAvailable` task exists so it costs one prompt rather than one per cycle. Installer users never see it at all: [InnoInstallerScript.iss:62](resources/InnoInstallerScript.iss:62) runs `--register` under the elevation already granted to setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)