### PR TITLE
Bump installer version to 1.9

### DIFF
--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.8"
+#define MyAppVersion "1.9"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"


### PR DESCRIPTION
The installer script still said `1.8` while the README advertises Bluetooth
support as new in 1.9. It's the only place in the repo carrying the app
version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)