### PR TITLE
Fix orphaned ViGEm pads left behind by a failed target add

### DIFF
--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -427,7 +427,8 @@ ControllerManager::EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
             if (sc->IsOpen()) sc->SetRumble(largeMotor, smallMotor);
         });
     if (!slot.vc->IsValid()) {
-        EventLog::Write("GAMEMODE: ViGEm virtual controller failed (driverMissing=%d)",
+        EventLog::Write("GAMEMODE: ViGEm virtual controller failed (stage=%s, err=0x%08X, driverMissing=%d)",
+                        slot.vc->FailStage(), slot.vc->LastError(),
                         slot.vc->IsDriverMissing() ? 1 : 0);
         if (slot.vc->IsDriverMissing()) vigemMissingOut = true;
         slot.vc.reset();

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -487,9 +487,13 @@ void TrayApp::RemoveTrayIcon() {
 }
 
 void TrayApp::UpdateTrayIcon(bool connected, bool gameModeActive, bool vigemMissing) {
-    if (vigemMissing) { ShowViGEmBalloon(); return; }
+    if (vigemMissing) ShowViGEmBalloon();
+    else              m_vigemBalloonShown = false;
 
+    // Fall through rather than returning early — the icon and tooltip still need
+    // to track the controller while the driver is unavailable.
     const wchar_t* tip = gameModeActive ? L"Steamless Controller — Steamless Mode ON"
+                       : vigemMissing   ? L"Steamless Controller — ViGEmBus driver unavailable"
                        : connected      ? L"Steamless Controller — Connected (Steamless Mode OFF)"
                                         : L"Steamless Controller — No controller found";
 
@@ -523,7 +527,14 @@ void TrayApp::OpenEventLog() {
                   EventLog::FilePath().c_str(), nullptr, SW_SHOWNORMAL);
 }
 
+// Latched: every failed game-mode enable calls back into UpdateTrayIcon, which
+// during an acquire-retry loop is several times a second — without this the user
+// gets a wall of identical balloons. UpdateTrayIcon clears the latch once the
+// driver is reachable again, so a genuine mid-session disappearance still warns.
 void TrayApp::ShowViGEmBalloon() {
+    if (m_vigemBalloonShown) return;
+    m_vigemBalloonShown = true;
+
     NOTIFYICONDATAW nid{};
     nid.cbSize           = sizeof(nid);
     nid.hWnd             = m_hwnd;
@@ -531,7 +542,9 @@ void TrayApp::ShowViGEmBalloon() {
     nid.uFlags           = NIF_INFO;
     nid.dwInfoFlags      = NIIF_WARNING;
     wcscpy_s(nid.szInfoTitle, L"Driver required");
-    wcscpy_s(nid.szInfo,      L"ViGEmBus is not installed. Click here to download it.");
+    wcscpy_s(nid.szInfo,
+             L"ViGEmBus is unavailable — not installed, or disabled in Device "
+             L"Manager under System devices. Click here to download it.");
     Shell_NotifyIconW(NIM_MODIFY, &nid);
 }
 

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -69,6 +69,7 @@ private:
     int                                m_acquireRetries = 0;
     ULONGLONG                          m_lastCycleTick  = 0;
     bool                               m_elevationBalloonShown = false;
+    bool                               m_vigemBalloonShown     = false;
     bool                               m_startupEnabled   = false;
     int                                m_startupMechanism = 0;  // 0 none, 1 Run key, 2 elevated task
     bool                               m_notificationsEnabled = true;  // disconnect/stall balloons

--- a/src/app/VirtualController.cpp
+++ b/src/app/VirtualController.cpp
@@ -150,10 +150,16 @@ VirtualController::VirtualController(ControllerPlatform platform, RumbleCallback
     : m_platform(platform), m_rumbleCallback(std::move(rumbleCallback))
 {
     m_client = vigem_alloc();
-    if (!m_client) { printf("[ViGEm] alloc failed\n"); return; }
+    if (!m_client) {
+        m_failStage = "vigem_alloc";
+        printf("[ViGEm] alloc failed\n");
+        return;
+    }
 
     VIGEM_ERROR err = vigem_connect(static_cast<PVIGEM_CLIENT>(m_client));
     if (!VIGEM_SUCCESS(err)) {
+        m_failStage = "vigem_connect";
+        m_lastError = static_cast<uint32_t>(err);
         if (err == VIGEM_ERROR_BUS_NOT_FOUND || err == VIGEM_ERROR_BUS_ACCESS_FAILED)
             m_driverMissing = true;
         vigem_free(static_cast<PVIGEM_CLIENT>(m_client));
@@ -164,11 +170,17 @@ VirtualController::VirtualController(ControllerPlatform platform, RumbleCallback
     m_target = (platform == ControllerPlatform::PlayStation)
         ? vigem_target_ds4_alloc()
         : vigem_target_x360_alloc();
-    if (!m_target) { printf("[ViGEm] target alloc failed\n"); return; }
+    if (!m_target) {
+        m_failStage = "vigem_target_alloc";
+        printf("[ViGEm] target alloc failed\n");
+        return;
+    }
 
     err = vigem_target_add(static_cast<PVIGEM_CLIENT>(m_client),
                            static_cast<PVIGEM_TARGET>(m_target));
     if (!VIGEM_SUCCESS(err)) {
+        m_failStage = "vigem_target_add";
+        m_lastError = static_cast<uint32_t>(err);
         printf("[ViGEm] target_add failed: 0x%08X\n", err);
         vigem_target_free(static_cast<PVIGEM_TARGET>(m_target));
         m_target = nullptr;
@@ -186,6 +198,8 @@ VirtualController::VirtualController(ControllerPlatform platform, RumbleCallback
             X360Notification,
             this);
         if (!VIGEM_SUCCESS(err)) {
+            m_failStage = "vigem_target_x360_register_notification";
+            m_lastError = static_cast<uint32_t>(err);
             printf("[ViGEm] notification registration failed: 0x%08X\n", err);
             vigem_target_remove(static_cast<PVIGEM_CLIENT>(m_client),
                                 static_cast<PVIGEM_TARGET>(m_target));

--- a/src/app/VirtualController.h
+++ b/src/app/VirtualController.h
@@ -19,6 +19,12 @@ public:
     bool IsValid()        const { return m_valid; }
     bool IsDriverMissing() const { return m_driverMissing; }
 
+    // Why construction failed. Only meaningful when !IsValid(); FailStage() names
+    // the ViGEm call that failed and LastError() carries its VIGEM_ERROR code
+    // (0 when the failing call returns no code, e.g. the allocators).
+    const char* FailStage() const { return m_failStage; }
+    uint32_t    LastError() const { return m_lastError; }
+
     void Update(const uint8_t* buf, size_t n, const BackButtonConfig& backCfg, bool backMouseEnabled);
     void OnRumble(uint8_t largeMotor, uint8_t smallMotor);
 
@@ -40,6 +46,8 @@ private:
     RumbleCallback m_rumbleCallback;
     bool   m_valid        = false;
     bool   m_driverMissing = false;
+    const char* m_failStage = "none";
+    uint32_t    m_lastError = 0;
 
     // DS4 touchpad tracking
     bool     m_trackpadMouseEnabled    = false;

--- a/third_party/ViGEmClient-b66d02d/src/ViGEmClient.cpp
+++ b/third_party/ViGEmClient-b66d02d/src/ViGEmClient.cpp
@@ -639,8 +639,26 @@ VIGEM_ERROR vigem_target_add(PVIGEM_CLIENT vigem, PVIGEM_TARGET target)
 
 				//
 				// Don't leave device connected if the wait call failed
-				// 
-				error = vigem_target_remove(vigem, target);
+				//
+				// LOCAL PATCH (SteamlessController): as shipped, this cleanup is a
+				// no-op. IOCTL_VIGEM_PLUGIN_TARGET above already succeeded, so the
+				// child device exists, but State is only set to CONNECTED on the two
+				// success paths above — so vigem_target_remove() trips its own
+				// "State != VIGEM_TARGET_CONNECTED" guard and returns without ever
+				// sending IOCTL_VIGEM_UNPLUG_TARGET. The device is then orphaned in
+				// the bus with no owning process until the machine reboots or the bus
+				// is restarted. SerialNo still holds the slot that was plugged in, so
+				// marking the target connected lets the unplug actually go out.
+				//
+				// The error code is restored afterwards: a successful unplug would
+				// otherwise make vigem_target_add() report VIGEM_ERROR_NONE (and
+				// register the target in pTargetsList below) for a device that is no
+				// longer plugged in. VIGEM_ERROR_TARGET_NOT_PLUGGED_IN is what the
+				// unpatched code effectively returned here.
+				//
+				target->State = VIGEM_TARGET_CONNECTED;
+				(void)vigem_target_remove(vigem, target);
+				error = VIGEM_ERROR_TARGET_NOT_PLUGGED_IN;
 				break;
 			}
 		}


### PR DESCRIPTION
## The bug

A failed `vigem_target_add()` leaves a virtual pad plugged into the ViGEm bus with no owning process. It survives the app exiting, holds an XInput slot, and only goes away on reboot.

`vigem_target_add()` plugs the child device in with `IOCTL_VIGEM_PLUGIN_TARGET`, then waits for it with `IOCTL_VIGEM_WAIT_DEVICE_READY`. When that wait fails, the cleanup path calls `vigem_target_remove()` — but `target->State` is only set to `VIGEM_TARGET_CONNECTED` on the two success paths above it, so the removal trips its own guard:

```c
if (target->State != VIGEM_TARGET_CONNECTED)
    return VIGEM_ERROR_TARGET_NOT_PLUGGED_IN;
```

and returns without ever sending `IOCTL_VIGEM_UNPLUG_TARGET`. The device was already created, so it stays. `VirtualController` then frees the target and nulls `m_target`, so the destructor's own `vigem_target_remove` is skipped too, and closing the bus handle doesn't reclaim it either.

## Evidence

Found on a live machine — an orphaned pad that had outlived the app by five hours and several sessions:

```
USB\VID_045E&PID_028E\01   Present=True  Status=OK  Parent=ROOT\SYSTEM\0001 (ViGEmBus)
LastArrivalDate: 19:57:25    LastRemovalDate: (empty)
```

with no `SteamlessController.exe` running. The event log names the moment:

```
19:57:23.786  cycling device (attempt 2) + RELEASE all handles
19:57:23.832  CONNECT mi_04
19:57:25.344  ViGEm virtual controller failed     <- add #1, orphaned as \01
19:57:25.555  GAMEMODE: enabled (mi_04)           <- add #2, became \02, 211 ms later
```

Two adds for the same slot 211 ms apart. The first leaked; the second worked. That also explains the serial numbering — with `\01` wedged, every later session had to take the next free serial.

The trigger is the acquire loop in `TryAcquireController` (10 iterations, 50 ms apart, each walking every slot). A device cycle has PnP busy re-enumerating the receiver's interfaces, so the new ViGEm child can't finish starting inside the wait.

## Changes

**`third_party/.../ViGEmClient.cpp`** — mark the target connected before the cleanup so the unplug is actually sent, and pin the return to `VIGEM_ERROR_TARGET_NOT_PLUGGED_IN`. Without pinning it, a successful unplug would report `VIGEM_ERROR_NONE` and register a target in `pTargetsList` that is no longer plugged in — the add really did fail and must keep saying so.

**`VirtualController` / `ControllerManager`** — record which ViGEm call failed and its error code, and log both. The old line was `driverMissing=%d`, which can't distinguish a missing bus from a failed target add. The new form is what identified a second, unrelated problem on first run:

```
GAMEMODE: ViGEm virtual controller failed (stage=vigem_connect, err=0xE0000001, driverMissing=1)
```

**`TrayApp`** — latch `ShowViGEmBalloon()` the way `ShowElevationBalloon()` already did. Every failed enable calls back into `UpdateTrayIcon`, several times a second during an acquire-retry loop, so an unavailable driver produced a continuous wall of identical balloons. The latch clears once the driver is reachable again so a genuine mid-session disappearance still warns. `UpdateTrayIcon` also no longer returns early on `vigemMissing`, so the icon and tooltip keep tracking the controller instead of freezing.

Also reworded that balloon. A **disabled** bus devnode reports the same `VIGEM_ERROR_BUS_NOT_FOUND` as an uninstalled one, and "ViGEmBus is not installed" sends users to the download page when the actual fix is Device Manager → System devices → Enable device.

## For reviewers

- The ViGEmClient change is a local patch to the vendored `b66d02d` snapshot. Upstream is archived, so no future sync will bring it in and none will clobber it.
- **Not yet exercised with a controller.** It compiles clean and the reasoning is backed by the log and devnode evidence above, but the fix path has not been observed firing end to end. The check is that `stage=vigem_target_add` appears in the log and no ViGEm child stays `Present=True` after game mode drops.
- Users already in the bad state don't need this to recover — a reboot always cleared live orphans, since ViGEm children are created at runtime and nothing recreates them at boot. This stops them being created.
- Follow-up, deliberately not in this PR: the acquire loop retries `vigem_target_add` on a ~50 ms cadence with no cooldown after a failure. The patch makes each failure harmless rather than permanent, so it's now a question of avoiding pointless devnode churn while PnP is already congested, not correctness.

To enumerate what the bus currently owns:

```powershell
$bus = (Get-PnpDevice -Class System | Where-Object Service -eq 'ViGEmBus').InstanceId
Get-PnpDevice | Where-Object { (Get-PnpDeviceProperty -InstanceId $_.InstanceId -KeyName DEVPKEY_Device_Parent -EA SilentlyContinue).Data -eq $bus } | Select-Object Status, Present, FriendlyName, InstanceId
```

`Present=True` with the app closed is the bug. `Present=False` rows are normal residue of correct operation.
