### PR TITLE
Bump installer version to 1.10

### DIFF
--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.9"
+#define MyAppVersion "1.10"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"


### PR DESCRIPTION
Covers the two fixes merged since 1.9:

- #53 — manual mode can now take the controller back from a running Steam, instead of requiring Steam to be closed
- #52 — a failed ViGEm target add no longer orphans a pad that holds an XInput slot until reboot

`resources/InnoInstallerScript.iss` is still the only place carrying the app version.

Nothing in the app compares version strings — `AppVersion` is a display and registry value only, and there is no `VersionInfoVersion` field derived from it. So `1.10` sorting below `1.9` lexically has no effect beyond how it reads in Programs and Features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)