### PR TITLE
Fix back button mapping override, and allow keyboard bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(SteamlessController WIN32
     src/app/ControllerManager.cpp
     src/app/VirtualController.cpp
     src/app/TrackpadMouse.cpp
+    src/app/KeyInput.cpp
     src/app/SteamWatcher.cpp
     src/app/DeviceRestart.cpp
     src/app/EventLog.cpp

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When **Steamless Mode** is active, the app disables the controller's built-in ke
 - System tray icon shows connection and mode status
 - **Steamless Mode** — disables lizard mode and exposes controller as Xbox 360 gamepad
 - **Trackpad Mouse** — use the right (or left) trackpad as a mouse cursor
-- **Back Buttons for Clicking** — map R4/R5 (or L4/L5) to left/right mouse click
+- **Back Buttons for Clicking** — the upper paddles (L4/R4) left-click by default; rebind any paddle to a gamepad button, right click, or Off
 - **Use Left Trackpad Instead** — mirror all trackpad/back-button functionality to the left side for left-handed users
 - **Start with Windows** — launch automatically at login
 - Settings persist across restarts

--- a/src/app/BackButtonConfig.h
+++ b/src/app/BackButtonConfig.h
@@ -2,7 +2,7 @@
 #include <cstdint>
 #include <string>
 
-// Actions a back paddle can be mapped to.
+// Built-in actions a back paddle can be mapped to.
 // Values are stable — persisted as DWORDs in the registry.
 // Entries 0-11 match the original ordering so existing settings are preserved.
 enum class BackButtonAction : uint8_t {
@@ -18,15 +18,6 @@ enum class BackButtonAction : uint8_t {
     Menu, View,
     L3, R3,
     COUNT
-};
-
-struct BackButtonConfig {
-    // Default: the upper paddles left-click the mouse (this used to be the
-    // "Back Buttons as Mouse Click" tray toggle), the lower paddles are unbound.
-    BackButtonAction l4 = BackButtonAction::LeftMouseButton;
-    BackButtonAction l5 = BackButtonAction::None;
-    BackButtonAction r4 = BackButtonAction::LeftMouseButton;
-    BackButtonAction r5 = BackButtonAction::None;
 };
 
 // String IDs match the JS input catalog (used in JSON messages to/from WebView2).
@@ -63,3 +54,124 @@ inline BackButtonAction BackButtonActionFromId(const std::string& id) {
     if (id == "R3")         return BackButtonAction::R3;
     return BackButtonAction::None;
 }
+
+// A paddle binding: either one of the built-in actions above, or a value drawn
+// from a space too large to enumerate (a keyboard virtual-key code, an extended
+// mouse button).
+//
+// Persisted as a single DWORD, (kind << 16) | code. Every value written by
+// builds that stored a bare BackButtonAction is 0-18, so its kind bits are
+// already zero and it decodes as Kind::Action — old settings load unchanged
+// with no migration step.
+struct BackButtonBinding {
+    enum class Kind : uint8_t {
+        Action      = 0,  // code is a BackButtonAction
+        Key         = 1,  // code is a Windows virtual-key code
+        MouseButton = 2,  // code is a MouseButtonCode
+    };
+
+    // Extended mouse buttons. Left and right live in BackButtonAction instead,
+    // where they were first persisted.
+    enum class MouseButtonCode : uint16_t { Middle = 0, X1 = 1, X2 = 2, COUNT };
+
+    Kind     kind = Kind::Action;
+    uint16_t code = static_cast<uint16_t>(BackButtonAction::None);
+
+    static BackButtonBinding FromAction(BackButtonAction a) {
+        return { Kind::Action, static_cast<uint16_t>(a) };
+    }
+    static BackButtonBinding FromKey(uint16_t vk) {
+        return { Kind::Key, vk };
+    }
+    static BackButtonBinding FromMouseButton(MouseButtonCode b) {
+        return { Kind::MouseButton, static_cast<uint16_t>(b) };
+    }
+
+    bool IsAction() const { return kind == Kind::Action; }
+
+    // The built-in action this binding names, or None when it is a key or an
+    // extended mouse button. Callers that only understand actions can switch on
+    // this directly — anything they cannot represent reads as "do nothing".
+    BackButtonAction AsAction() const {
+        return kind == Kind::Action ? static_cast<BackButtonAction>(code)
+                                    : BackButtonAction::None;
+    }
+    bool IsAction(BackButtonAction a) const {
+        return kind == Kind::Action && code == static_cast<uint16_t>(a);
+    }
+
+    bool operator==(const BackButtonBinding& o) const {
+        return kind == o.kind && code == o.code;
+    }
+    bool operator!=(const BackButtonBinding& o) const { return !(*this == o); }
+
+    uint32_t Pack() const {
+        return (static_cast<uint32_t>(kind) << 16) | code;
+    }
+
+    // Anything unrecognised — a corrupt value, or one written by a future build
+    // that knows kinds we do not — degrades to None rather than being applied.
+    static BackButtonBinding Unpack(uint32_t packed) {
+        const auto kind = static_cast<Kind>((packed >> 16) & 0xFF);
+        const auto code = static_cast<uint16_t>(packed & 0xFFFF);
+        switch (kind) {
+        case Kind::Action:
+            return code < static_cast<uint16_t>(BackButtonAction::COUNT)
+                 ? BackButtonBinding{ Kind::Action, code }
+                 : BackButtonBinding{};
+        case Kind::Key:
+            return code != 0 ? BackButtonBinding{ Kind::Key, code }
+                             : BackButtonBinding{};
+        case Kind::MouseButton:
+            return code < static_cast<uint16_t>(MouseButtonCode::COUNT)
+                 ? BackButtonBinding{ Kind::MouseButton, code }
+                 : BackButtonBinding{};
+        }
+        return {};
+    }
+
+    // Wire format for the WebView2 UI. Built-in actions keep their bare ids
+    // ("A", "leftMouse", "none"); the open-ended kinds are prefixed. Staying
+    // with flat strings keeps the hand-rolled JSON reader in RemapWindow usable.
+    std::string Id() const {
+        switch (kind) {
+        case Kind::Key:
+            return "key:" + std::to_string(code);
+        case Kind::MouseButton:
+            switch (static_cast<MouseButtonCode>(code)) {
+            case MouseButtonCode::Middle: return "mouse:middle";
+            case MouseButtonCode::X1:     return "mouse:x1";
+            case MouseButtonCode::X2:     return "mouse:x2";
+            default:                      return "none";
+            }
+        case Kind::Action:
+        default:
+            return BackButtonActionId(AsAction());
+        }
+    }
+
+    static BackButtonBinding FromId(const std::string& id) {
+        if (id.rfind("key:", 0) == 0) {
+            uint32_t vk = 0;
+            for (size_t i = 4; i < id.size(); ++i) {
+                if (id[i] < '0' || id[i] > '9') return {};
+                vk = vk * 10 + static_cast<uint32_t>(id[i] - '0');
+                if (vk > 0xFFFF) return {};
+            }
+            return vk != 0 ? FromKey(static_cast<uint16_t>(vk)) : BackButtonBinding{};
+        }
+        if (id == "mouse:middle") return FromMouseButton(MouseButtonCode::Middle);
+        if (id == "mouse:x1")     return FromMouseButton(MouseButtonCode::X1);
+        if (id == "mouse:x2")     return FromMouseButton(MouseButtonCode::X2);
+        return FromAction(BackButtonActionFromId(id));
+    }
+};
+
+struct BackButtonConfig {
+    // Default: the upper paddles left-click the mouse (this used to be the
+    // "Back Buttons as Mouse Click" tray toggle), the lower paddles are unbound.
+    BackButtonBinding l4 = BackButtonBinding::FromAction(BackButtonAction::LeftMouseButton);
+    BackButtonBinding l5 = BackButtonBinding::FromAction(BackButtonAction::None);
+    BackButtonBinding r4 = BackButtonBinding::FromAction(BackButtonAction::LeftMouseButton);
+    BackButtonBinding r5 = BackButtonBinding::FromAction(BackButtonAction::None);
+};

--- a/src/app/BackButtonConfig.h
+++ b/src/app/BackButtonConfig.h
@@ -12,7 +12,7 @@ enum class BackButtonAction : uint8_t {
     LB, RB, LT, RT,
     // Row 3 — d-pad
     DPadUp, DPadDown, DPadLeft, DPadRight,
-    // Row 4 — stick clicks, menu buttons, mouse buttons, and "none" (natural behavior)
+    // Row 4 — stick clicks, menu buttons, mouse buttons, and "none" (paddle does nothing)
     LeftMouseButton, RightMouseButton,
     None,
     Menu, View,
@@ -21,10 +21,11 @@ enum class BackButtonAction : uint8_t {
 };
 
 struct BackButtonConfig {
-    // Default: each back paddle uses its natural behavior (mouse click when that mode is on).
-    BackButtonAction l4 = BackButtonAction::None;
+    // Default: the upper paddles left-click the mouse (this used to be the
+    // "Back Buttons as Mouse Click" tray toggle), the lower paddles are unbound.
+    BackButtonAction l4 = BackButtonAction::LeftMouseButton;
     BackButtonAction l5 = BackButtonAction::None;
-    BackButtonAction r4 = BackButtonAction::None;
+    BackButtonAction r4 = BackButtonAction::LeftMouseButton;
     BackButtonAction r5 = BackButtonAction::None;
 };
 

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -42,6 +42,12 @@ struct ControllerManager::Slot {
     // again on release, so rebinding a paddle mid-hold still releases cleanly.
     BackButtonBinding paddleHeld[4];
 
+    // Auto-repeat for held key bindings. When the next repeat is due, and the
+    // gap to use after that — both captured at press time from the user's
+    // keyboard settings, so the rate cannot shift mid-hold.
+    std::chrono::steady_clock::time_point paddleRepeatAt[4]{};
+    std::chrono::milliseconds             paddleRepeatGap[4]{};
+
     // Haptic edge-detection state for touch (movement ticks).
     bool    hapticWasRightTouching = false;
     bool    hapticWasLeftTouching  = false;
@@ -823,7 +829,12 @@ void ControllerManager::ReadLoop(Slot* slot) {
                 const auto& e = edges[i];
                 if (e.cur == e.prev) continue;
                 if (e.cur) {
-                    if (SendPaddleInput(e.binding, true)) slot->paddleHeld[i] = e.binding;
+                    if (SendPaddleInput(e.binding, true)) {
+                        slot->paddleHeld[i]     = e.binding;
+                        slot->paddleRepeatGap[i] = KeyRepeatInterval();
+                        slot->paddleRepeatAt[i]  =
+                            std::chrono::steady_clock::now() + KeyRepeatDelay();
+                    }
                 } else {
                     // Release what the press sent, not what the binding says
                     // now — the two differ if the user rebound mid-hold.
@@ -831,6 +842,22 @@ void ControllerManager::ReadLoop(Slot* slot) {
                     slot->paddleHeld[i] = BackButtonBinding{};
                 }
             }
+        }
+
+        // Auto-repeat held keys. A physical keyboard repeats because its own
+        // firmware keeps sending the key, not because Windows tracks the key as
+        // down, so injected input has to reproduce that itself. Keys only —
+        // mice do not repeat when held, and gamepad bindings are held state in
+        // the pad report, where a repeat would be meaningless.
+        for (size_t i = 0; i < std::size(slot->paddleHeld); ++i) {
+            const auto& held = slot->paddleHeld[i];
+            if (held.kind != BackButtonBinding::Kind::Key) continue;
+
+            const auto now = std::chrono::steady_clock::now();
+            if (now < slot->paddleRepeatAt[i]) continue;
+
+            SendKeyInput(held.code, true);
+            slot->paddleRepeatAt[i] = now + slot->paddleRepeatGap[i];
         }
 
         // Button capture for the remap window (press-to-bind).

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -2,6 +2,7 @@
 #include "EventLog.h"
 #include "VirtualController.h"
 #include "TrackpadMouse.h"
+#include "KeyInput.h"
 #include "steam/SteamController.h"
 #include <Windows.h>
 #include <algorithm>
@@ -9,6 +10,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstring>
+#include <iterator>
 #include <memory>
 #include <thread>
 #include <utility>
@@ -34,10 +36,11 @@ struct ControllerManager::Slot {
     // thread for that timeout on every one of those attempts.
     std::chrono::steady_clock::time_point lastSilentAt{};
 
-    // Mouse buttons currently held down by a back paddle, so leaving game mode
-    // mid-press releases them instead of stranding the button down.
-    bool    paddleMouseLeftDown  = false;
-    bool    paddleMouseRightDown = false;
+    // What each paddle (L4, L5, R4, R5) is currently holding down, so leaving
+    // game mode mid-press releases it instead of stranding the input down.
+    // Records what the press actually sent rather than reading the binding
+    // again on release, so rebinding a paddle mid-hold still releases cleanly.
+    BackButtonBinding paddleHeld[4];
 
     // Haptic edge-detection state for touch (movement ticks).
     bool    hapticWasRightTouching = false;
@@ -204,7 +207,7 @@ ControllerManager::~ControllerManager() {
         if (slot->gameModeActive) {
             StopReadLoop(*slot);
             slot->trackpad.Reset();
-            ReleasePaddleMouseButtons(*slot);
+            ReleaseHeldPaddleInputs(*slot);
             slot->vc.reset();
             slot->gameModeActive = false;
         }
@@ -284,17 +287,44 @@ void ControllerManager::SetBackButtonConfig(const BackButtonConfig& cfg) {
     // change takes effect on the very next report.
 }
 
-void ControllerManager::ReleasePaddleMouseButtons(Slot& slot) {
-    auto send = [](DWORD flags) {
+// Sends the key or mouse event a binding stands for. Gamepad actions reach the
+// virtual pad instead and are ignored here. Returns whether anything was sent.
+static bool SendPaddleInput(const BackButtonBinding& binding, bool down) {
+    auto sendMouse = [](DWORD flags) {
         INPUT inp{};
         inp.type       = INPUT_MOUSE;
         inp.mi.dwFlags = flags;
         SendInput(1, &inp, sizeof(INPUT));
     };
-    if (slot.paddleMouseLeftDown)  send(MOUSEEVENTF_LEFTUP);
-    if (slot.paddleMouseRightDown) send(MOUSEEVENTF_RIGHTUP);
-    slot.paddleMouseLeftDown  = false;
-    slot.paddleMouseRightDown = false;
+
+    switch (binding.kind) {
+    case BackButtonBinding::Kind::Key:
+        SendKeyInput(binding.code, down);
+        return true;
+
+    case BackButtonBinding::Kind::MouseButton:
+        // Extended mouse buttons are not bindable yet.
+        return false;
+
+    case BackButtonBinding::Kind::Action:
+        if (binding.IsAction(BackButtonAction::LeftMouseButton)) {
+            sendMouse(down ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP);
+            return true;
+        }
+        if (binding.IsAction(BackButtonAction::RightMouseButton)) {
+            sendMouse(down ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP);
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+void ControllerManager::ReleaseHeldPaddleInputs(Slot& slot) {
+    for (auto& held : slot.paddleHeld) {
+        SendPaddleInput(held, false);
+        held = BackButtonBinding{};
+    }
 }
 
 void ControllerManager::SetControllerPlatform(ControllerPlatform platform) {
@@ -458,7 +488,7 @@ ControllerManager::EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
     EventLog::Write("GAMEMODE: enabled %ls", slot.path.c_str());
     slot.gameModeActive = true;
     slot.trackpad.Reset();
-    ReleasePaddleMouseButtons(slot);
+    ReleaseHeldPaddleInputs(slot);
     slot.trackpad.SetTrackpadEnabled(m_trackpadMouseEnabled);
     slot.trackpad.SetUseLeftTrackpad(m_useLeftTrackpad);
     StartReadLoop(slot);
@@ -472,7 +502,7 @@ void ControllerManager::DisableGameModeSlot(Slot& slot) {
     if (slot.sc->IsOpen())
         slot.sc->SetRumble(0, 0);
     slot.trackpad.Reset();
-    ReleasePaddleMouseButtons(slot);
+    ReleaseHeldPaddleInputs(slot);
     slot.vc.reset();
     slot.sc->EnableLizardMode();
     // Reopen shared so Steam can obtain write access — game mode is no longer active.
@@ -778,8 +808,9 @@ void ControllerManager::ReadLoop(Slot* slot) {
             slot->hapticWasLeftTouching  = lt;
         }
 
-        // Fire mouse button events for back paddles mapped to LeftMouseButton/RightMouseButton.
-        // Uses edge detection so we only send DOWN on press and UP on release.
+        // Deliver back paddles bound to a key or a mouse button. These go out
+        // through SendInput rather than the virtual pad. Edge-detected so each
+        // press sends exactly one down and each release exactly one up.
         if (hasPrev) {
             struct PaddleEdge { bool cur; bool prev; const BackButtonBinding& binding; };
             const PaddleEdge edges[] = {
@@ -788,17 +819,17 @@ void ControllerManager::ReadLoop(Slot* slot) {
                 { n>2 && (buf[2]&SteamController::BTN_R4)!=0, (prevBuf[2]&SteamController::BTN_R4)!=0, m_backConfig.r4 },
                 { n>3 && (buf[3]&SteamController::BTN_R5)!=0, (prevBuf[3]&SteamController::BTN_R5)!=0, m_backConfig.r5 },
             };
-            for (const auto& e : edges) {
+            for (size_t i = 0; i < std::size(edges); ++i) {
+                const auto& e = edges[i];
                 if (e.cur == e.prev) continue;
-                DWORD flag = 0;
-                if (e.binding.IsAction(BackButtonAction::LeftMouseButton)) {
-                    flag = e.cur ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP;
-                    slot->paddleMouseLeftDown = e.cur;
-                } else if (e.binding.IsAction(BackButtonAction::RightMouseButton)) {
-                    flag = e.cur ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP;
-                    slot->paddleMouseRightDown = e.cur;
+                if (e.cur) {
+                    if (SendPaddleInput(e.binding, true)) slot->paddleHeld[i] = e.binding;
+                } else {
+                    // Release what the press sent, not what the binding says
+                    // now — the two differ if the user rebound mid-hold.
+                    SendPaddleInput(slot->paddleHeld[i], false);
+                    slot->paddleHeld[i] = BackButtonBinding{};
                 }
-                if (flag) { INPUT inp{}; inp.type = INPUT_MOUSE; inp.mi.dwFlags = flag; SendInput(1, &inp, sizeof(INPUT)); }
             }
         }
 

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -116,6 +116,8 @@ struct ControllerManager::Slot {
 static bool DetectCapture(const uint8_t* cur, const uint8_t* prev,
                           BackButtonAction& out)
 {
+    // Controller input only ever yields a built-in action; the caller wraps the
+    // result. Keyboard and mouse capture arrive through the UI, not this loop.
     using BA = BackButtonAction;
 
     // Helper: rising edge on a single bit in a byte.
@@ -304,7 +306,7 @@ void ControllerManager::SetControllerPlatform(ControllerPlatform platform) {
     }
 }
 
-void ControllerManager::StartButtonCapture(std::function<void(BackButtonAction)> callback) {
+void ControllerManager::StartButtonCapture(std::function<void(const BackButtonBinding&)> callback) {
     std::lock_guard<std::mutex> lk(m_captureMutex);
     m_captureCallback = std::move(callback);
     m_capturing = true;
@@ -779,7 +781,7 @@ void ControllerManager::ReadLoop(Slot* slot) {
         // Fire mouse button events for back paddles mapped to LeftMouseButton/RightMouseButton.
         // Uses edge detection so we only send DOWN on press and UP on release.
         if (hasPrev) {
-            struct PaddleEdge { bool cur; bool prev; BackButtonAction action; };
+            struct PaddleEdge { bool cur; bool prev; const BackButtonBinding& binding; };
             const PaddleEdge edges[] = {
                 { n>4 && (buf[4]&SteamController::BTN_L4)!=0, (prevBuf[4]&SteamController::BTN_L4)!=0, m_backConfig.l4 },
                 { n>4 && (buf[4]&SteamController::BTN_L5)!=0, (prevBuf[4]&SteamController::BTN_L5)!=0, m_backConfig.l5 },
@@ -789,10 +791,10 @@ void ControllerManager::ReadLoop(Slot* slot) {
             for (const auto& e : edges) {
                 if (e.cur == e.prev) continue;
                 DWORD flag = 0;
-                if (e.action == BackButtonAction::LeftMouseButton) {
+                if (e.binding.IsAction(BackButtonAction::LeftMouseButton)) {
                     flag = e.cur ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP;
                     slot->paddleMouseLeftDown = e.cur;
-                } else if (e.action == BackButtonAction::RightMouseButton) {
+                } else if (e.binding.IsAction(BackButtonAction::RightMouseButton)) {
                     flag = e.cur ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP;
                     slot->paddleMouseRightDown = e.cur;
                 }
@@ -807,7 +809,8 @@ void ControllerManager::ReadLoop(Slot* slot) {
             if (DetectCapture(buf, prevBuf, captured)) {
                 m_capturing = false;
                 std::lock_guard<std::mutex> lk(m_captureMutex);
-                if (m_captureCallback) m_captureCallback(captured);
+                if (m_captureCallback)
+                    m_captureCallback(BackButtonBinding::FromAction(captured));
             }
         }
 

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -34,6 +34,11 @@ struct ControllerManager::Slot {
     // thread for that timeout on every one of those attempts.
     std::chrono::steady_clock::time_point lastSilentAt{};
 
+    // Mouse buttons currently held down by a back paddle, so leaving game mode
+    // mid-press releases them instead of stranding the button down.
+    bool    paddleMouseLeftDown  = false;
+    bool    paddleMouseRightDown = false;
+
     // Haptic edge-detection state for touch (movement ticks).
     bool    hapticWasRightTouching = false;
     bool    hapticWasLeftTouching  = false;
@@ -197,6 +202,7 @@ ControllerManager::~ControllerManager() {
         if (slot->gameModeActive) {
             StopReadLoop(*slot);
             slot->trackpad.Reset();
+            ReleasePaddleMouseButtons(*slot);
             slot->vc.reset();
             slot->gameModeActive = false;
         }
@@ -276,10 +282,17 @@ void ControllerManager::SetBackButtonConfig(const BackButtonConfig& cfg) {
     // change takes effect on the very next report.
 }
 
-void ControllerManager::SetBackButtonsEnabled(bool enabled) {
-    m_backButtonsEnabled = enabled;
-    for (auto& slot : m_slots)
-        slot->trackpad.SetBackButtonsEnabled(enabled);
+void ControllerManager::ReleasePaddleMouseButtons(Slot& slot) {
+    auto send = [](DWORD flags) {
+        INPUT inp{};
+        inp.type       = INPUT_MOUSE;
+        inp.mi.dwFlags = flags;
+        SendInput(1, &inp, sizeof(INPUT));
+    };
+    if (slot.paddleMouseLeftDown)  send(MOUSEEVENTF_LEFTUP);
+    if (slot.paddleMouseRightDown) send(MOUSEEVENTF_RIGHTUP);
+    slot.paddleMouseLeftDown  = false;
+    slot.paddleMouseRightDown = false;
 }
 
 void ControllerManager::SetControllerPlatform(ControllerPlatform platform) {
@@ -443,9 +456,9 @@ ControllerManager::EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
     EventLog::Write("GAMEMODE: enabled %ls", slot.path.c_str());
     slot.gameModeActive = true;
     slot.trackpad.Reset();
+    ReleasePaddleMouseButtons(slot);
     slot.trackpad.SetTrackpadEnabled(m_trackpadMouseEnabled);
     slot.trackpad.SetUseLeftTrackpad(m_useLeftTrackpad);
-    slot.trackpad.SetBackButtonsEnabled(m_backButtonsEnabled);
     StartReadLoop(slot);
     return GameModeOutcome::Enabled;
 }
@@ -457,6 +470,7 @@ void ControllerManager::DisableGameModeSlot(Slot& slot) {
     if (slot.sc->IsOpen())
         slot.sc->SetRumble(0, 0);
     slot.trackpad.Reset();
+    ReleasePaddleMouseButtons(slot);
     slot.vc.reset();
     slot.sc->EnableLizardMode();
     // Reopen shared so Steam can obtain write access — game mode is no longer active.
@@ -563,7 +577,7 @@ void ControllerManager::ReadLoop(Slot* slot) {
 
         if (!SteamController::IsStateReportId(buf[0])) continue;
 
-        if (slot->vc) slot->vc->Update(buf, n, m_backConfig, m_backButtonsEnabled);
+        if (slot->vc) slot->vc->Update(buf, n, m_backConfig);
         slot->trackpad.Update(buf, n);
 
         // Trackpad haptics.
@@ -764,8 +778,7 @@ void ControllerManager::ReadLoop(Slot* slot) {
 
         // Fire mouse button events for back paddles mapped to LeftMouseButton/RightMouseButton.
         // Uses edge detection so we only send DOWN on press and UP on release.
-        // Skipped when backButtonsEnabled — TrackpadMouse already handles L4/R4 in that mode.
-        if (!m_backButtonsEnabled && hasPrev) {
+        if (hasPrev) {
             struct PaddleEdge { bool cur; bool prev; BackButtonAction action; };
             const PaddleEdge edges[] = {
                 { n>4 && (buf[4]&SteamController::BTN_L4)!=0, (prevBuf[4]&SteamController::BTN_L4)!=0, m_backConfig.l4 },
@@ -776,8 +789,13 @@ void ControllerManager::ReadLoop(Slot* slot) {
             for (const auto& e : edges) {
                 if (e.cur == e.prev) continue;
                 DWORD flag = 0;
-                if      (e.action == BackButtonAction::LeftMouseButton)  flag = e.cur ? MOUSEEVENTF_LEFTDOWN  : MOUSEEVENTF_LEFTUP;
-                else if (e.action == BackButtonAction::RightMouseButton) flag = e.cur ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP;
+                if (e.action == BackButtonAction::LeftMouseButton) {
+                    flag = e.cur ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP;
+                    slot->paddleMouseLeftDown = e.cur;
+                } else if (e.action == BackButtonAction::RightMouseButton) {
+                    flag = e.cur ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_RIGHTUP;
+                    slot->paddleMouseRightDown = e.cur;
+                }
                 if (flag) { INPUT inp{}; inp.type = INPUT_MOUSE; inp.mi.dwFlags = flag; SendInput(1, &inp, sizeof(INPUT)); }
             }
         }

--- a/src/app/ControllerManager.h
+++ b/src/app/ControllerManager.h
@@ -57,14 +57,12 @@ public:
     void SetTrackpadMouseEnabled(bool enabled);
     void SetUseLeftTrackpad(bool enabled);
     void SetBackButtonConfig(const BackButtonConfig& cfg);
-    void SetBackButtonsEnabled(bool enabled);
     void SetControllerPlatform(ControllerPlatform platform);
 
     bool IsConnected()              const { return !m_slots.empty(); }
     bool IsGameModeActive()         const;
     bool IsTrackpadMouseEnabled()   const { return m_trackpadMouseEnabled; }
     bool IsUseLeftTrackpad()        const { return m_useLeftTrackpad; }
-    bool IsBackButtonsEnabled()     const { return m_backButtonsEnabled; }
     ControllerPlatform GetControllerPlatform() const { return m_controllerPlatform; }
     const BackButtonConfig& GetBackButtonConfig() const { return m_backConfig; }
 
@@ -81,6 +79,7 @@ private:
     GameModeOutcome EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
                                        uint32_t stateWaitMs);
     void DisableGameModeSlot(Slot& slot);
+    void ReleasePaddleMouseButtons(Slot& slot);
     void StartReadLoop(Slot& slot);
     void StopReadLoop(Slot& slot);
     void ReadLoop(Slot* slot);
@@ -91,7 +90,6 @@ private:
     std::vector<std::unique_ptr<Slot>> m_slots;
     bool                               m_trackpadMouseEnabled = false;
     bool                               m_useLeftTrackpad      = false;
-    bool                               m_backButtonsEnabled   = false;
     bool                               m_steamPresent         = false;
     ControllerPlatform                 m_controllerPlatform   = ControllerPlatform::Xbox;
     BackButtonConfig                   m_backConfig;

--- a/src/app/ControllerManager.h
+++ b/src/app/ControllerManager.h
@@ -68,7 +68,7 @@ public:
 
     // Called by RemapWindow when a row enters/exits listening state.
     // Callback fires on the read thread — use PostMessage to marshal to the UI thread.
-    void StartButtonCapture(std::function<void(BackButtonAction)> callback);
+    void StartButtonCapture(std::function<void(const BackButtonBinding&)> callback);
     void StopButtonCapture();
 
 private:
@@ -94,7 +94,7 @@ private:
     ControllerPlatform                 m_controllerPlatform   = ControllerPlatform::Xbox;
     BackButtonConfig                   m_backConfig;
 
-    std::atomic<bool>                        m_capturing{false};
-    std::mutex                               m_captureMutex;
-    std::function<void(BackButtonAction)>    m_captureCallback;
+    std::atomic<bool>                            m_capturing{false};
+    std::mutex                                   m_captureMutex;
+    std::function<void(const BackButtonBinding&)> m_captureCallback;
 };

--- a/src/app/ControllerManager.h
+++ b/src/app/ControllerManager.h
@@ -79,7 +79,7 @@ private:
     GameModeOutcome EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
                                        uint32_t stateWaitMs);
     void DisableGameModeSlot(Slot& slot);
-    void ReleasePaddleMouseButtons(Slot& slot);
+    void ReleaseHeldPaddleInputs(Slot& slot);
     void StartReadLoop(Slot& slot);
     void StopReadLoop(Slot& slot);
     void ReadLoop(Slot* slot);

--- a/src/app/KeyInput.cpp
+++ b/src/app/KeyInput.cpp
@@ -1,0 +1,153 @@
+#include "KeyInput.h"
+#include <Windows.h>
+#include <iterator>
+
+namespace {
+
+struct JsCodeToVk { const char* code; uint16_t vk; };
+
+// KeyboardEvent.code values are physical positions, so a binding made on one
+// keyboard layout means the same physical key on another. Escape is absent on
+// purpose — the remap window uses it to cancel listening.
+const JsCodeToVk kCodeMap[] = {
+    // Letters
+    {"KeyA",'A'},{"KeyB",'B'},{"KeyC",'C'},{"KeyD",'D'},{"KeyE",'E'},{"KeyF",'F'},
+    {"KeyG",'G'},{"KeyH",'H'},{"KeyI",'I'},{"KeyJ",'J'},{"KeyK",'K'},{"KeyL",'L'},
+    {"KeyM",'M'},{"KeyN",'N'},{"KeyO",'O'},{"KeyP",'P'},{"KeyQ",'Q'},{"KeyR",'R'},
+    {"KeyS",'S'},{"KeyT",'T'},{"KeyU",'U'},{"KeyV",'V'},{"KeyW",'W'},{"KeyX",'X'},
+    {"KeyY",'Y'},{"KeyZ",'Z'},
+
+    // Digit row
+    {"Digit0",'0'},{"Digit1",'1'},{"Digit2",'2'},{"Digit3",'3'},{"Digit4",'4'},
+    {"Digit5",'5'},{"Digit6",'6'},{"Digit7",'7'},{"Digit8",'8'},{"Digit9",'9'},
+
+    // Whitespace and editing
+    {"Space",       VK_SPACE},
+    {"Enter",       VK_RETURN},
+    {"Tab",         VK_TAB},
+    {"Backspace",   VK_BACK},
+    {"Delete",      VK_DELETE},
+    {"Insert",      VK_INSERT},
+
+    // Navigation
+    {"ArrowUp",     VK_UP},
+    {"ArrowDown",   VK_DOWN},
+    {"ArrowLeft",   VK_LEFT},
+    {"ArrowRight",  VK_RIGHT},
+    {"Home",        VK_HOME},
+    {"End",         VK_END},
+    {"PageUp",      VK_PRIOR},
+    {"PageDown",    VK_NEXT},
+
+    // Modifiers — bound to the specific left/right key, not the merged VK_SHIFT
+    {"ShiftLeft",    VK_LSHIFT},   {"ShiftRight",   VK_RSHIFT},
+    {"ControlLeft",  VK_LCONTROL}, {"ControlRight", VK_RCONTROL},
+    {"AltLeft",      VK_LMENU},    {"AltRight",     VK_RMENU},
+
+    // Function row
+    {"F1",VK_F1},{"F2",VK_F2},{"F3",VK_F3},{"F4",VK_F4},{"F5",VK_F5},{"F6",VK_F6},
+    {"F7",VK_F7},{"F8",VK_F8},{"F9",VK_F9},{"F10",VK_F10},{"F11",VK_F11},{"F12",VK_F12},
+
+    // Punctuation (OEM codes are positional, which suits a physical binding)
+    {"Minus",        VK_OEM_MINUS},
+    {"Equal",        VK_OEM_PLUS},
+    {"BracketLeft",  VK_OEM_4},
+    {"BracketRight", VK_OEM_6},
+    {"Backslash",    VK_OEM_5},
+    {"Semicolon",    VK_OEM_1},
+    {"Quote",        VK_OEM_7},
+    {"Backquote",    VK_OEM_3},
+    {"Comma",        VK_OEM_COMMA},
+    {"Period",       VK_OEM_PERIOD},
+    {"Slash",        VK_OEM_2},
+
+    // Numpad
+    {"Numpad0",VK_NUMPAD0},{"Numpad1",VK_NUMPAD1},{"Numpad2",VK_NUMPAD2},
+    {"Numpad3",VK_NUMPAD3},{"Numpad4",VK_NUMPAD4},{"Numpad5",VK_NUMPAD5},
+    {"Numpad6",VK_NUMPAD6},{"Numpad7",VK_NUMPAD7},{"Numpad8",VK_NUMPAD8},
+    {"Numpad9",VK_NUMPAD9},
+    {"NumpadAdd",      VK_ADD},
+    {"NumpadSubtract", VK_SUBTRACT},
+    {"NumpadMultiply", VK_MULTIPLY},
+    {"NumpadDivide",   VK_DIVIDE},
+    {"NumpadDecimal",  VK_DECIMAL},
+    // Windows gives numpad Enter the same virtual key as the main one and
+    // separates them by scan code alone. A binding stores only the VK, so this
+    // one behaves as a plain Enter — which is what nearly all software wants.
+    {"NumpadEnter",    VK_RETURN},
+
+    // Locks
+    {"CapsLock",   VK_CAPITAL},
+    {"NumLock",    VK_NUMLOCK},
+    {"ScrollLock", VK_SCROLL},
+};
+
+// The navigation cluster shares scan codes with the numpad and is told apart
+// only by the 0xE0 extended prefix — drop it and an Up arrow arrives as numpad
+// 8. MapVirtualKey is documented to report that prefix under MAPVK_VK_TO_VSC_EX
+// but does not actually do so for these keys, so the set is spelled out here.
+bool IsExtendedKey(uint16_t vk) {
+    switch (vk) {
+    case VK_RCONTROL: case VK_RMENU:
+    case VK_INSERT:   case VK_DELETE:
+    case VK_HOME:     case VK_END:
+    case VK_PRIOR:    case VK_NEXT:
+    case VK_UP:       case VK_DOWN:
+    case VK_LEFT:     case VK_RIGHT:
+    case VK_NUMLOCK:  case VK_DIVIDE:
+    case VK_SNAPSHOT:
+    case VK_LWIN:     case VK_RWIN:  case VK_APPS:
+        return true;
+    default:
+        return false;
+    }
+}
+
+struct ScanCode { WORD scan; bool extended; };
+
+ScanCode ScanCodeFor(uint16_t vk) {
+    // _EX is still the right lookup for the scan code itself: it distinguishes
+    // left from right modifiers, which the plain mapping collapses.
+    const UINT mapped = MapVirtualKeyW(vk, MAPVK_VK_TO_VSC_EX);
+    return { static_cast<WORD>(mapped & 0xFF), IsExtendedKey(vk) };
+}
+
+}  // namespace
+
+uint16_t VkFromJsCode(const std::string& jsCode) {
+    for (const auto& e : kCodeMap)
+        if (jsCode == e.code) return e.vk;
+    return 0;
+}
+
+std::wstring KeyDisplayName(uint16_t vk) {
+    if (vk == 0) return L"Key";
+
+    const ScanCode sc = ScanCodeFor(vk);
+    if (sc.scan == 0) return L"Key";
+
+    // GetKeyNameText takes the scan code and extended flag positioned as they
+    // appear in a WM_KEYDOWN lParam.
+    LONG lParam = static_cast<LONG>(sc.scan) << 16;
+    if (sc.extended) lParam |= (1L << 24);
+
+    wchar_t buf[64] = {};
+    const int n = GetKeyNameTextW(lParam, buf, static_cast<int>(std::size(buf)));
+    return n > 0 ? std::wstring(buf, static_cast<size_t>(n)) : std::wstring(L"Key");
+}
+
+void SendKeyInput(uint16_t vk, bool down) {
+    if (vk == 0) return;
+
+    const ScanCode sc = ScanCodeFor(vk);
+    if (sc.scan == 0) return;
+
+    INPUT input = {};
+    input.type       = INPUT_KEYBOARD;
+    input.ki.wVk     = 0;  // ignored, and must be zero, when sending a scan code
+    input.ki.wScan   = sc.scan;
+    input.ki.dwFlags = KEYEVENTF_SCANCODE;
+    if (sc.extended) input.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+    if (!down)       input.ki.dwFlags |= KEYEVENTF_KEYUP;
+    SendInput(1, &input, sizeof(INPUT));
+}

--- a/src/app/KeyInput.cpp
+++ b/src/app/KeyInput.cpp
@@ -151,3 +151,21 @@ void SendKeyInput(uint16_t vk, bool down) {
     if (!down)       input.ki.dwFlags |= KEYEVENTF_KEYUP;
     SendInput(1, &input, sizeof(INPUT));
 }
+
+std::chrono::milliseconds KeyRepeatDelay() {
+    // 0-3, meaning roughly 250ms to 1000ms in 250ms steps.
+    DWORD setting = 1;
+    if (!SystemParametersInfoW(SPI_GETKEYBOARDDELAY, 0, &setting, 0) || setting > 3)
+        setting = 1;
+    return std::chrono::milliseconds(250 * (static_cast<int>(setting) + 1));
+}
+
+std::chrono::milliseconds KeyRepeatInterval() {
+    // 0-31, meaning roughly 2.5 to 30 repeats per second. Windows documents only
+    // the endpoints, so interpolate the rate between them.
+    DWORD setting = 31;
+    if (!SystemParametersInfoW(SPI_GETKEYBOARDSPEED, 0, &setting, 0) || setting > 31)
+        setting = 31;
+    const double perSecond = 2.5 + (30.0 - 2.5) * (static_cast<double>(setting) / 31.0);
+    return std::chrono::milliseconds(static_cast<long long>(1000.0 / perSecond + 0.5));
+}

--- a/src/app/KeyInput.h
+++ b/src/app/KeyInput.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+// Keyboard support for paddle bindings.
+//
+// Capture happens in the remap window's WebView2 page rather than through a
+// keyboard hook: the page is already focused while a row is listening, and a
+// low-level hook is a heavy, AV-bait mechanism for a convenience feature.
+// The page reports the physical key as a KeyboardEvent.code string, which this
+// module turns into a virtual-key code.
+
+// Maps a KeyboardEvent.code value ("KeyA", "Space", "ArrowUp") to a Windows
+// virtual-key code. Returns 0 for anything unrecognised or not bindable.
+uint16_t VkFromJsCode(const std::string& jsCode);
+
+// Human-readable name for a virtual-key code, from the active keyboard layout —
+// so a non-US layout shows its own key names. Falls back to "Key" if the layout
+// has no name for it.
+std::wstring KeyDisplayName(uint16_t vk);
+
+// Presses or releases a key. Sends a scan code rather than a virtual key, and
+// flags the extended keys, because software that reads scan codes directly
+// (games, in particular) sees nothing useful otherwise.
+void SendKeyInput(uint16_t vk, bool down);

--- a/src/app/KeyInput.h
+++ b/src/app/KeyInput.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <chrono>
 #include <cstdint>
 #include <string>
 
@@ -22,4 +23,15 @@ std::wstring KeyDisplayName(uint16_t vk);
 // Presses or releases a key. Sends a scan code rather than a virtual key, and
 // flags the extended keys, because software that reads scan codes directly
 // (games, in particular) sees nothing useful otherwise.
+//
+// Holding a key down does not repeat on its own: auto-repeat comes from the
+// keyboard's own typematic behaviour, not from Windows noticing a key is held,
+// and injected input has no firmware behind it. A caller that wants a held key
+// to repeat has to re-send the press itself, paced by the two values below.
 void SendKeyInput(uint16_t vk, bool down);
+
+// The user's Windows keyboard settings: how long a key must be held before it
+// starts repeating, and the gap between repeats after that. Read fresh rather
+// than cached at startup so a change in Control Panel is picked up.
+std::chrono::milliseconds KeyRepeatDelay();
+std::chrono::milliseconds KeyRepeatInterval();

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -419,12 +419,12 @@ LRESULT RemapWindow::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     }
 
     case WM_BUTTON_CAPTURED: {
-        // Marshalled from the read thread via PostMessage.
-        auto action = static_cast<BackButtonAction>(static_cast<int>(wp));
-        const char* id = BackButtonActionId(action);
+        // Marshalled from the read thread via PostMessage, packed into WPARAM.
+        const std::string id =
+            BackButtonBinding::Unpack(static_cast<uint32_t>(wp)).Id();
         if (m_webview) {
             std::wstring json = L"{\"type\":\"buttonCaptured\",\"button\":\"";
-            json += std::wstring(id, id + strlen(id));
+            json += std::wstring(id.begin(), id.end());
             json += L"\"}";
             m_webview->PostWebMessageAsString(json.c_str());
         }
@@ -665,10 +665,10 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
         std::string row = JsonStr(msg, "row");
         if (!row.empty() && m_mgr) {
             HWND hwnd = m_hwnd;
-            m_mgr->StartButtonCapture([hwnd](BackButtonAction action) {
+            m_mgr->StartButtonCapture([hwnd](const BackButtonBinding& binding) {
                 // Called from the read thread — use PostMessage to marshal to UI.
                 PostMessageW(hwnd, WM_BUTTON_CAPTURED,
-                             static_cast<WPARAM>(static_cast<int>(action)), 0);
+                             static_cast<WPARAM>(binding.Pack()), 0);
             });
         }
 
@@ -681,10 +681,10 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
         if (bStart != std::string::npos) {
             std::string sub = msg.substr(bStart);
             BackButtonConfig cfg;
-            cfg.l4 = BackButtonActionFromId(JsonStr(sub, "L4"));
-            cfg.l5 = BackButtonActionFromId(JsonStr(sub, "L5"));
-            cfg.r4 = BackButtonActionFromId(JsonStr(sub, "R4"));
-            cfg.r5 = BackButtonActionFromId(JsonStr(sub, "R5"));
+            cfg.l4 = BackButtonBinding::FromId(JsonStr(sub, "L4"));
+            cfg.l5 = BackButtonBinding::FromId(JsonStr(sub, "L5"));
+            cfg.r4 = BackButtonBinding::FromId(JsonStr(sub, "R4"));
+            cfg.r5 = BackButtonBinding::FromId(JsonStr(sub, "R5"));
             m_config = cfg;
             if (m_applyCallback) m_applyCallback(cfg);
         }
@@ -699,11 +699,9 @@ void RemapWindow::SendInitState() {
     if (!m_webview) return;
 
     // Convert ASCII action ID string to wstring without char→wchar_t narrowing warnings.
-    auto wid = [](BackButtonAction a) -> std::wstring {
-        const char* s = BackButtonActionId(a);
-        std::wstring w;
-        for (; *s; ++s) w += static_cast<wchar_t>(*s);
-        return w;
+    auto wid = [](const BackButtonBinding& b) -> std::wstring {
+        const std::string s = b.Id();
+        return std::wstring(s.begin(), s.end());
     };
 
     std::wstring json =

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -104,7 +104,7 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 <div id="body">
   <div>
     <h2>Back Button Mapping</h2>
-    <p class="instr">Click <b>Rebind</b> on a button, then press any gamepad button on your controller. The new binding shows up here instantly.</p>
+    <p class="instr">Click <b>Rebind</b> on a button, then press any gamepad button on your controller. The new binding shows up here instantly. Pick <b>Off</b> to stop a paddle doing anything at all.</p>
   </div>
   <div class="group">
     <div class="group-label">LEFT GRIP</div>
@@ -127,11 +127,12 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 
 <script>
 'use strict';
-// ---- Defaults (each back button maps to itself = natural behavior) ----
-var DEFAULTS = {L4:'none',L5:'none',R4:'none',R5:'none'};
+// ---- Defaults (upper paddles left-click, lower paddles unbound) ----
+// Keep in sync with BackButtonConfig in BackButtonConfig.h.
+var DEFAULTS = {L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none'};
 
 // ---- State ----
-var bindings = {L4:'none',L5:'none',R4:'none',R5:'none'};
+var bindings = {L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none'};
 var listening = null;
 var flash = null;
 var flashTimer = null;
@@ -157,6 +158,7 @@ var INPUTS = [
   {id:'view',      glyph:'VEW',     label:'View',        bg:'#2a3a2a',fg:'#9ac89a'},
   {id:'L3',        glyph:'L3',      label:'L3 Stick',    bg:'#37485a',fg:'#cdd9e3'},
   {id:'R3',        glyph:'R3',      label:'R3 Stick',    bg:'#37485a',fg:'#cdd9e3'},
+  {id:'none',      glyph:'OFF',     label:'Off',         bg:'#1e2d3d',fg:'#5a7a9a'},
 ];
 var byId = {};
 INPUTS.forEach(function(t){byId[t.id]=t;});
@@ -167,6 +169,7 @@ var PICKER_ROWS = [
   ['LB','LT','RB','RT'],
   ['Up','Down','Left','Right'],
   ['L3','R3','menu','view','leftMouse','rightMouse'],
+  ['none'],
 ];
 
 var ROWS = [
@@ -223,7 +226,7 @@ function resetRow(rowId){
 }
 function resetDefaults(){
   cancelListening();
-  bindings={L4:'none',L5:'none',R4:'none',R5:'none'};
+  bindings={L4:DEFAULTS.L4,L5:DEFAULTS.L5,R4:DEFAULTS.R4,R5:DEFAULTS.R5};
   flash=null;
   clearTimeout(flashTimer);
   renderAll();
@@ -246,9 +249,7 @@ function renderRow(def){
   var isL=listening===def.id, isF=flash===def.id;
   el.className='row'+(isL?' listening':isF?' flash':'');
   var curBind=bindings[def.id];
-  var tgt=(curBind==='none'||!byId[curBind])
-    ? {id:'none',glyph:def.id,label:'Default (natural)',bg:'#1e2d3d',fg:'#5a7a9a'}
-    : byId[curBind];
+  var tgt=byId[curBind]||byId['none'];
   var rightHTML;
   if(isL){
     rightHTML='<div class="listen-right">'+
@@ -275,7 +276,7 @@ function renderRow(def){
       return '<div class="picker-row">'+pills+'</div>';
     }).join('');
     pickerHTML='<div class="picker">'+
-      '<div class="picker-label">NO CONTROLLER? PICK MANUALLY</div>'+
+      '<div class="picker-label">OR PICK MANUALLY</div>'+
       '<div class="picker-rows">'+pickerRows+'</div></div>';
   }
   el.innerHTML='<div class="row-top">'+

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -1,4 +1,5 @@
 #include "RemapWindow.h"
+#include "KeyInput.h"
 #include "ControllerManager.h"
 #include <shellapi.h>
 #include <shlobj.h>
@@ -104,7 +105,7 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 <div id="body">
   <div>
     <h2>Back Button Mapping</h2>
-    <p class="instr">Click <b>Rebind</b> on a button, then press any gamepad button on your controller. The new binding shows up here instantly. Pick <b>Off</b> to stop a paddle doing anything at all.</p>
+    <p class="instr">Click <b>Rebind</b> on a button, then press any gamepad button on your controller &#8212; or any key on your keyboard. The new binding shows up here instantly. Pick <b>Off</b> to stop a paddle doing anything at all.</p>
   </div>
   <div class="group">
     <div class="group-label">LEFT GRIP</div>
@@ -134,6 +135,9 @@ var DEFAULTS = {L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none'};
 // ---- State ----
 var bindings = {L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none'};
 var listening = null;
+// Display names for key bindings, keyed by binding id. Supplied by C++ from the
+// active keyboard layout — the catalog below can't cover them.
+var keyLabels = {};
 var flash = null;
 var flashTimer = null;
 var applyTimer = null;
@@ -189,9 +193,12 @@ if(window.chrome&&window.chrome.webview){
     var msg=JSON.parse(e.data);
     if(msg.type==='init'){
       bindings=msg.bindings;
+      keyLabels=msg.labels||{};
       renderAll();
     } else if(msg.type==='buttonCaptured'){
-      if(listening&&byId[msg.button]) doBind(listening,msg.button);
+      if(!listening) return;
+      if(msg.label) keyLabels[msg.button]=msg.label;
+      doBind(listening,msg.button);
     }
   });
 }
@@ -240,6 +247,16 @@ function applyBindings(){
   postMsg({type:'apply',bindings:bindings});
 }
 // ---- Render helpers ----
+// Resolves a binding id to something renderable. Keys aren't in the static
+// catalog, so they're built on the fly from the label C++ sent.
+function inputInfo(id){
+  if(byId[id]) return byId[id];
+  if(id&&id.indexOf('key:')===0){
+    var lbl=keyLabels[id]||'Key';
+    return {id:id,glyph:(lbl.length<=3?lbl:'KEY'),label:lbl,bg:'#4a3524',fg:'#f2d5ab'};
+  }
+  return byId['none'];
+}
 function chipHTML(t,cls){
   return '<div class="'+cls+'" style="background:'+t.bg+';color:'+t.fg+';">'+t.glyph+'</div>';
 }
@@ -249,11 +266,11 @@ function renderRow(def){
   var isL=listening===def.id, isF=flash===def.id;
   el.className='row'+(isL?' listening':isF?' flash':'');
   var curBind=bindings[def.id];
-  var tgt=byId[curBind]||byId['none'];
+  var tgt=inputInfo(curBind);
   var rightHTML;
   if(isL){
     rightHTML='<div class="listen-right">'+
-      '<span class="listen-pill"><span class="pulse-dot"></span>Press a button...</span>'+
+      '<span class="listen-pill"><span class="pulse-dot"></span>Press a button or key...</span>'+
       '<button class="btn-row-reset" onclick="resetRow(\''+def.id+'\')">Reset</button>'+
       '<button class="btn-cancel" onclick="cancelListening()">&#10005;</button>'+
       '</div>';
@@ -307,7 +324,14 @@ document.getElementById('titlebar').addEventListener('mousedown',function(e){
 });
 
 document.addEventListener('keydown',function(e){
-  if(e.key==='Escape') cancelListening();
+  // Escape stays the cancel affordance, so it is deliberately not bindable.
+  if(e.key==='Escape'){cancelListening();return;}
+  if(!listening||e.repeat) return;
+  // Swallow the key so it can't also drive the page (Tab moving focus, Space
+  // clicking the focused button) while a row is listening.
+  e.preventDefault();
+  e.stopPropagation();
+  postMsg({type:'keyCaptured',code:e.code});
 });
 
 renderAll();
@@ -418,18 +442,10 @@ LRESULT RemapWindow::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         return hit;
     }
 
-    case WM_BUTTON_CAPTURED: {
+    case WM_BUTTON_CAPTURED:
         // Marshalled from the read thread via PostMessage, packed into WPARAM.
-        const std::string id =
-            BackButtonBinding::Unpack(static_cast<uint32_t>(wp)).Id();
-        if (m_webview) {
-            std::wstring json = L"{\"type\":\"buttonCaptured\",\"button\":\"";
-            json += std::wstring(id.begin(), id.end());
-            json += L"\"}";
-            m_webview->PostWebMessageAsString(json.c_str());
-        }
+        PostCapturedBinding(BackButtonBinding::Unpack(static_cast<uint32_t>(wp)));
         return 0;
-    }
 
     case WM_CLOSE:
         ShowWindow(hwnd, SW_HIDE);
@@ -633,6 +649,32 @@ void RemapWindow::OnControllerReady(ICoreWebView2Controller* ctrl) {
 // ---------------------------------------------------------------------------
 
 // Minimal JSON string extractor — finds "key":"value" in a flat JSON object.
+// Key names come from the keyboard layout, so they can contain characters that
+// would otherwise terminate or corrupt the JSON string we build by hand — the
+// backslash key is the obvious one.
+static std::wstring JsonEscape(const std::wstring& s) {
+    std::wstring out;
+    out.reserve(s.size() + 8);
+    for (wchar_t c : s) {
+        switch (c) {
+        case L'"':  out += L"\\\""; break;
+        case L'\\': out += L"\\\\"; break;
+        default:
+            if (c >= 0x20) out += c;  // drop control characters
+            break;
+        }
+    }
+    return out;
+}
+
+// Display label for a binding, or empty when the page's static catalog already
+// has a name for it. Only keys need one — their names come from the layout.
+static std::wstring BindingLabel(const BackButtonBinding& binding) {
+    return binding.kind == BackButtonBinding::Kind::Key
+         ? KeyDisplayName(binding.code)
+         : std::wstring();
+}
+
 static std::string JsonStr(const std::string& json, const std::string& key) {
     std::string needle = "\"" + key + "\":\"";
     size_t pos = json.find(needle);
@@ -672,6 +714,16 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
             });
         }
 
+    } else if (type == "keyCaptured") {
+        // Arrives from the page's keydown handler, already on the UI thread.
+        // Unmappable keys are ignored so the row keeps listening rather than
+        // binding to nothing.
+        const uint16_t vk = VkFromJsCode(JsonStr(msg, "code"));
+        if (vk != 0) {
+            if (m_mgr) m_mgr->StopButtonCapture();
+            PostCapturedBinding(BackButtonBinding::FromKey(vk));
+        }
+
     } else if (type == "stopListening") {
         if (m_mgr) m_mgr->StopButtonCapture();
 
@@ -695,6 +747,14 @@ void RemapWindow::PostToWebView(const std::wstring& jsonStr) {
     if (m_webview) m_webview->PostWebMessageAsString(jsonStr.c_str());
 }
 
+void RemapWindow::PostCapturedBinding(const BackButtonBinding& binding) {
+    const std::string id = binding.Id();
+    std::wstring json = L"{\"type\":\"buttonCaptured\",\"button\":\"";
+    json += std::wstring(id.begin(), id.end());
+    json += L"\",\"label\":\"" + JsonEscape(BindingLabel(binding)) + L"\"}";
+    PostToWebView(json);
+}
+
 void RemapWindow::SendInitState() {
     if (!m_webview) return;
 
@@ -704,12 +764,25 @@ void RemapWindow::SendInitState() {
         return std::wstring(s.begin(), s.end());
     };
 
+    // Key bindings need a label the page cannot derive on its own — their names
+    // come from the keyboard layout. Sent as an id→name map so a paddle pair
+    // bound to the same key contributes one entry.
+    std::wstring labels;
+    for (const auto* b : { &m_config.l4, &m_config.l5, &m_config.r4, &m_config.r5 }) {
+        const std::wstring label = BindingLabel(*b);
+        if (label.empty()) continue;
+        const std::wstring entry = L"\"" + wid(*b) + L"\":\"" + JsonEscape(label) + L"\"";
+        if (labels.find(entry) != std::wstring::npos) continue;
+        if (!labels.empty()) labels += L",";
+        labels += entry;
+    }
+
     std::wstring json =
         L"{\"type\":\"init\",\"bindings\":{"
         L"\"L4\":\"" + wid(m_config.l4) + L"\","
         L"\"L5\":\"" + wid(m_config.l5) + L"\","
         L"\"R4\":\"" + wid(m_config.r4) + L"\","
         L"\"R5\":\"" + wid(m_config.r5) + L"\""
-        L"}}";
+        L"},\"labels\":{" + labels + L"}}";
     PostToWebView(json);
 }

--- a/src/app/RemapWindow.h
+++ b/src/app/RemapWindow.h
@@ -34,6 +34,10 @@ private:
     void PostToWebView(const std::wstring& jsonStr);
     void SendInitState();
 
+    // Tells the page a binding was captured. The page applies it to whichever
+    // row is listening — it owns that state, not us.
+    void PostCapturedBinding(const BackButtonBinding& binding);
+
     // Called from the read thread via PostMessage — marshals a captured button
     // back to the UI thread so we can call PostWebMessageAsString safely.
     static constexpr UINT WM_BUTTON_CAPTURED = WM_APP + 1;

--- a/src/app/TrackpadMouse.cpp
+++ b/src/app/TrackpadMouse.cpp
@@ -13,12 +13,8 @@ static void SendMouseButton(DWORD flags) {
 
 void TrackpadMouse::Reset() {
     if (m_prevClick) SendMouseButton(MOUSEEVENTF_LEFTUP);
-    if (m_prevL4)    SendMouseButton(MOUSEEVENTF_LEFTUP);
-    if (m_prevR4)    SendMouseButton(MOUSEEVENTF_LEFTUP);
     m_touching  = false;
     m_prevClick = false;
-    m_prevL4    = false;
-    m_prevR4    = false;
     m_prevX     = 0;
     m_prevY     = 0;
     m_remX      = 0.0f;
@@ -26,21 +22,8 @@ void TrackpadMouse::Reset() {
 }
 
 void TrackpadMouse::Update(const uint8_t* buf, size_t n) {
-    // L4 (upper-left paddle) and R4 (upper-right paddle) → left mouse click.
-    // This works independently of trackpad mouse mode.
-    if (m_backButtonsEnabled && n > 4) {
-        bool l4 = (buf[4] & SteamController::BTN_L4) != 0;
-        bool r4 = (n > 2) && (buf[2] & SteamController::BTN_R4) != 0;
-        if (l4 != m_prevL4) {
-            SendMouseButton(l4 ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP);
-            m_prevL4 = l4;
-        }
-        if (r4 != m_prevR4) {
-            SendMouseButton(r4 ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP);
-            m_prevR4 = r4;
-        }
-    }
-
+    // Back paddles mapped to a mouse button are handled by ControllerManager,
+    // alongside every other paddle binding.
     if (n < 30 || !m_trackpadEnabled) return;
 
     const uint8_t b2 = buf[4];

--- a/src/app/TrackpadMouse.h
+++ b/src/app/TrackpadMouse.h
@@ -6,8 +6,6 @@ class TrackpadMouse {
 public:
     void SetTrackpadEnabled(bool enabled)   { m_trackpadEnabled  = enabled; }
     void SetUseLeftTrackpad(bool enabled)   { m_useLeftTrackpad  = enabled; }
-    void SetBackButtonsEnabled(bool enabled){ m_backButtonsEnabled = enabled; }
-    bool IsBackButtonsEnabled() const       { return m_backButtonsEnabled; }
 
     void Update(const uint8_t* buf, size_t n);
     void Reset();
@@ -15,12 +13,9 @@ public:
 private:
     bool     m_trackpadEnabled   = false;
     bool     m_useLeftTrackpad   = false;
-    bool     m_backButtonsEnabled = false;
 
     bool     m_touching  = false;
     bool     m_prevClick = false;
-    bool     m_prevL4    = false;
-    bool     m_prevR4    = false;
     int16_t  m_prevX     = 0;
     int16_t  m_prevY     = 0;
     float    m_remX      = 0.0f;  // sub-pixel movement carry

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -753,11 +753,12 @@ void TrayApp::LoadSettings() {
     // Existing installs keep exactly the bindings they had — the new
     // click-by-default only applies to fresh installs, which never reach here
     // and so take the BackButtonConfig defaults.
+    const DWORD unbound = BackButtonBinding::FromAction(BackButtonAction::None).Pack();
     BackButtonConfig cfg;
-    cfg.l4 = static_cast<BackButtonAction>(readDw(L"BackBtnL4", static_cast<DWORD>(BackButtonAction::None)));
-    cfg.l5 = static_cast<BackButtonAction>(readDw(L"BackBtnL5", static_cast<DWORD>(BackButtonAction::None)));
-    cfg.r4 = static_cast<BackButtonAction>(readDw(L"BackBtnR4", static_cast<DWORD>(BackButtonAction::None)));
-    cfg.r5 = static_cast<BackButtonAction>(readDw(L"BackBtnR5", static_cast<DWORD>(BackButtonAction::None)));
+    cfg.l4 = BackButtonBinding::Unpack(readDw(L"BackBtnL4", unbound));
+    cfg.l5 = BackButtonBinding::Unpack(readDw(L"BackBtnL5", unbound));
+    cfg.r4 = BackButtonBinding::Unpack(readDw(L"BackBtnR4", unbound));
+    cfg.r5 = BackButtonBinding::Unpack(readDw(L"BackBtnR5", unbound));
 
     // Migrate the retired "Back Buttons as Mouse Click" toggle into real
     // bindings. The toggle used to hijack L4/R4 for a left click and silently
@@ -766,8 +767,9 @@ void TrayApp::LoadSettings() {
     // all along and starts working again now that nothing overrides it.
     const bool migrateBackMouse = readDw(L"BackButtons", 0) != 0;
     if (migrateBackMouse) {
-        if (cfg.l4 == BackButtonAction::None) cfg.l4 = BackButtonAction::LeftMouseButton;
-        if (cfg.r4 == BackButtonAction::None) cfg.r4 = BackButtonAction::LeftMouseButton;
+        const auto leftClick = BackButtonBinding::FromAction(BackButtonAction::LeftMouseButton);
+        if (cfg.l4.IsAction(BackButtonAction::None)) cfg.l4 = leftClick;
+        if (cfg.r4.IsAction(BackButtonAction::None)) cfg.r4 = leftClick;
     }
     m_controller->SetBackButtonConfig(cfg);
 
@@ -813,10 +815,10 @@ void TrayApp::SaveSettings() {
     writeDw(L"ControllerPlatform",  m_controller->GetControllerPlatform() == ControllerPlatform::PlayStation ? 1 : 0);
 
     const auto& cfg = m_controller->GetBackButtonConfig();
-    writeDw(L"BackBtnL4", static_cast<DWORD>(cfg.l4));
-    writeDw(L"BackBtnL5", static_cast<DWORD>(cfg.l5));
-    writeDw(L"BackBtnR4", static_cast<DWORD>(cfg.r4));
-    writeDw(L"BackBtnR5", static_cast<DWORD>(cfg.r5));
+    writeDw(L"BackBtnL4", cfg.l4.Pack());
+    writeDw(L"BackBtnL5", cfg.l5.Pack());
+    writeDw(L"BackBtnR4", cfg.r4.Pack());
+    writeDw(L"BackBtnR5", cfg.r5.Pack());
 
     RegCloseKey(key);
 }

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -191,10 +191,6 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         case IDM_REMAP_BACK:
             OpenRemapWindow();
             break;
-        case IDM_BACKBUTTONS:
-            m_controller->SetBackButtonsEnabled(!m_controller->IsBackButtonsEnabled());
-            SaveSettings();
-            break;
         case IDM_LEFT_TRACKPAD:
             m_controller->SetUseLeftTrackpad(!m_controller->IsUseLeftTrackpad());
             SaveSettings();
@@ -749,17 +745,30 @@ void TrayApp::LoadSettings() {
                : mode == 1 ? AutoMode::OffWhileSteam
                            : AutoMode::Manual;
     m_controller->SetTrackpadMouseEnabled(readDw(L"TrackpadMouse",   0) != 0);
-    m_controller->SetBackButtonsEnabled  (readDw(L"BackButtons",     0) != 0);
     m_controller->SetUseLeftTrackpad     (readDw(L"UseLeftTrackpad", 0) != 0);
     m_controller->SetControllerPlatform  (readDw(L"ControllerPlatform", 0) != 0
                                           ? ControllerPlatform::PlayStation
                                           : ControllerPlatform::Xbox);
 
+    // Existing installs keep exactly the bindings they had — the new
+    // click-by-default only applies to fresh installs, which never reach here
+    // and so take the BackButtonConfig defaults.
     BackButtonConfig cfg;
     cfg.l4 = static_cast<BackButtonAction>(readDw(L"BackBtnL4", static_cast<DWORD>(BackButtonAction::None)));
     cfg.l5 = static_cast<BackButtonAction>(readDw(L"BackBtnL5", static_cast<DWORD>(BackButtonAction::None)));
     cfg.r4 = static_cast<BackButtonAction>(readDw(L"BackBtnR4", static_cast<DWORD>(BackButtonAction::None)));
     cfg.r5 = static_cast<BackButtonAction>(readDw(L"BackBtnR5", static_cast<DWORD>(BackButtonAction::None)));
+
+    // Migrate the retired "Back Buttons as Mouse Click" toggle into real
+    // bindings. The toggle used to hijack L4/R4 for a left click and silently
+    // discard whatever they were bound to, so only fill in the paddles that
+    // have no binding of their own — an explicit mapping was the user's intent
+    // all along and starts working again now that nothing overrides it.
+    const bool migrateBackMouse = readDw(L"BackButtons", 0) != 0;
+    if (migrateBackMouse) {
+        if (cfg.l4 == BackButtonAction::None) cfg.l4 = BackButtonAction::LeftMouseButton;
+        if (cfg.r4 == BackButtonAction::None) cfg.r4 = BackButtonAction::LeftMouseButton;
+    }
     m_controller->SetBackButtonConfig(cfg);
 
     m_notificationsEnabled = readDw(L"ShowNotifications", 1) != 0;
@@ -771,6 +780,17 @@ void TrayApp::LoadSettings() {
     m_startupEnabled   = m_startupMechanism != 0;
 
     RegCloseKey(key);
+
+    // Persist the migrated bindings and drop the retired value, so the fill-in
+    // above runs exactly once and a later choice of "Off" is not resurrected.
+    if (migrateBackMouse) {
+        SaveSettings();
+        HKEY writeKey;
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, REG_KEY, 0, KEY_SET_VALUE, &writeKey) == ERROR_SUCCESS) {
+            RegDeleteValueW(writeKey, L"BackButtons");
+            RegCloseKey(writeKey);
+        }
+    }
 }
 
 void TrayApp::SaveSettings() {
@@ -789,7 +809,6 @@ void TrayApp::SaveSettings() {
     writeDw(L"StartupMechanism",    static_cast<DWORD>(m_startupMechanism));
     writeDw(L"ShowNotifications",   m_notificationsEnabled ? 1 : 0);
     writeDw(L"TrackpadMouse",       m_controller->IsTrackpadMouseEnabled()  ? 1 : 0);
-    writeDw(L"BackButtons",         m_controller->IsBackButtonsEnabled()    ? 1 : 0);
     writeDw(L"UseLeftTrackpad",     m_controller->IsUseLeftTrackpad()       ? 1 : 0);
     writeDw(L"ControllerPlatform",  m_controller->GetControllerPlatform() == ControllerPlatform::PlayStation ? 1 : 0);
 
@@ -806,7 +825,6 @@ void TrayApp::ShowContextMenu() {
     bool connected    = m_controller->IsConnected();
     bool gameModeOn   = m_controller->IsGameModeActive();
     bool trackpadOn   = m_controller->IsTrackpadMouseEnabled();
-    bool backMouseOn  = m_controller->IsBackButtonsEnabled();
     bool leftPad      = m_controller->IsUseLeftTrackpad();
     bool startupOn    = m_startupEnabled;
 
@@ -842,9 +860,6 @@ void TrayApp::ShowContextMenu() {
 
     AppendMenuW(menu, MF_STRING | (trackpadOn ? MF_CHECKED : MF_UNCHECKED),
                 IDM_TRACKPAD, L"Enable Trackpad Mouse");
-
-    AppendMenuW(menu, MF_STRING | (backMouseOn ? MF_CHECKED : MF_UNCHECKED),
-                IDM_BACKBUTTONS, L"Back Buttons as Mouse Click");
 
     AppendMenuW(menu, MF_STRING | (leftPad ? MF_CHECKED : MF_UNCHECKED),
                 IDM_LEFT_TRACKPAD, L"Use Left Trackpad Instead");

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -93,7 +93,6 @@ private:
     static constexpr UINT IDM_REMAP_BACK    = 1004;
     static constexpr UINT IDM_LEFT_TRACKPAD = 1005;
     static constexpr UINT IDM_STARTUP       = 1006;
-    static constexpr UINT IDM_BACKBUTTONS   = 1007;
     static constexpr UINT IDM_PLATFORM_XBOX = 1008;
     static constexpr UINT IDM_PLATFORM_PS   = 1009;
     static constexpr UINT IDM_MODE_MANUAL   = 1010;

--- a/src/app/VirtualController.cpp
+++ b/src/app/VirtualController.cpp
@@ -278,7 +278,7 @@ void VirtualController::SetTrackpadMouseClaim(bool enabled, bool useLeftTrackpad
 }
 
 void VirtualController::Update(const uint8_t* buf, size_t n,
-                               const BackButtonConfig& backCfg, bool backMouseEnabled) {
+                               const BackButtonConfig& backCfg) {
     if (!m_valid) return;
 
     if (m_platform == ControllerPlatform::PlayStation) {
@@ -356,11 +356,11 @@ void VirtualController::Update(const uint8_t* buf, size_t n,
                 }
             };
             if (n > 4) {
-                if (!backMouseEnabled && (buf[4] & SteamController::BTN_L4)) applyBack(backCfg.l4);
+                if (buf[4] & SteamController::BTN_L4) applyBack(backCfg.l4);
                 if (buf[4] & SteamController::BTN_L5) applyBack(backCfg.l5);
             }
             if (n > 2) {
-                if (!backMouseEnabled && (buf[2] & SteamController::BTN_R4)) applyBack(backCfg.r4);
+                if (buf[2] & SteamController::BTN_R4) applyBack(backCfg.r4);
             }
             if (n > 3) {
                 if (buf[3] & SteamController::BTN_R5) applyBack(backCfg.r5);
@@ -465,11 +465,11 @@ void VirtualController::Update(const uint8_t* buf, size_t n,
         XUSB_REPORT report = TranslateX360(buf, n);
 
         if (n > 4) {
-            if (!backMouseEnabled && (buf[4] & SteamController::BTN_L4)) ApplyBackActionX360(backCfg.l4, report);
+            if (buf[4] & SteamController::BTN_L4) ApplyBackActionX360(backCfg.l4, report);
             if (buf[4] & SteamController::BTN_L5) ApplyBackActionX360(backCfg.l5, report);
         }
         if (n > 2) {
-            if (!backMouseEnabled && (buf[2] & SteamController::BTN_R4)) ApplyBackActionX360(backCfg.r4, report);
+            if (buf[2] & SteamController::BTN_R4) ApplyBackActionX360(backCfg.r4, report);
         }
         if (n > 3) {
             if (buf[3] & SteamController::BTN_R5) ApplyBackActionX360(backCfg.r5, report);

--- a/src/app/VirtualController.cpp
+++ b/src/app/VirtualController.cpp
@@ -27,8 +27,10 @@ static VOID CALLBACK X360Notification(
         static_cast<VirtualController*>(userData)->OnRumble(largeMotor, smallMotor);
 }
 
-static void ApplyBackActionX360(BackButtonAction action, XUSB_REPORT& r) {
-    switch (action) {
+// Keys and mouse buttons are delivered by ControllerManager via SendInput, not
+// through the virtual pad, so they fall through as "no gamepad input".
+static void ApplyBackActionX360(const BackButtonBinding& binding, XUSB_REPORT& r) {
+    switch (binding.AsAction()) {
     case BackButtonAction::A:         r.wButtons |= XUSB_GAMEPAD_A;              break;
     case BackButtonAction::B:         r.wButtons |= XUSB_GAMEPAD_B;              break;
     case BackButtonAction::X:         r.wButtons |= XUSB_GAMEPAD_X;              break;
@@ -333,9 +335,9 @@ void VirtualController::Update(const uint8_t* buf, size_t n,
             r.bThumbRX = s16ToU8(rx);
             r.bThumbRY = static_cast<uint8_t>(255u - s16ToU8(ry));
 
-            // Back paddles
-            auto applyBack = [&](BackButtonAction action) {
-                switch (action) {
+            // Back paddles. As above, non-gamepad bindings fall through.
+            auto applyBack = [&](const BackButtonBinding& binding) {
+                switch (binding.AsAction()) {
                 case BackButtonAction::A:         r.wButtons |= DS4_BUTTON_CROSS;          break;
                 case BackButtonAction::B:         r.wButtons |= DS4_BUTTON_CIRCLE;         break;
                 case BackButtonAction::X:         r.wButtons |= DS4_BUTTON_SQUARE;         break;

--- a/src/app/VirtualController.h
+++ b/src/app/VirtualController.h
@@ -25,7 +25,7 @@ public:
     const char* FailStage() const { return m_failStage; }
     uint32_t    LastError() const { return m_lastError; }
 
-    void Update(const uint8_t* buf, size_t n, const BackButtonConfig& backCfg, bool backMouseEnabled);
+    void Update(const uint8_t* buf, size_t n, const BackButtonConfig& backCfg);
     void OnRumble(uint8_t largeMotor, uint8_t smallMotor);
 
     // DS4-only: update battery level shown in the DS4 report.


### PR DESCRIPTION
Four commits, each self-contained. Ordered so the bug fix stands alone and the refactor lands separately from the feature it enables.

---

## 1. Fix custom back button mappings being ignored in mouse click mode

A user reported that mapping RT to a back button did nothing. **"Back Buttons as Mouse Click" hijacked L4 and R4 unconditionally** — the virtual controller skipped their bindings entirely while the option was on.

Two things made this hard to self-diagnose:

- **Only the upper paddles were affected.** L5 and R5 kept working, so the symptom read as "two of my four paddles are dead" rather than pointing at the toggle.
- **The same gate suppressed the Left/Right Click bindings** the remap window already offered, so enabling the feature disabled the very capability it existed to provide.

The toggle was a strict subset of the remap window, so it's retired rather than taught to cooperate. L4/R4 now default to left click so a fresh install still clicks out of the box, and an explicit **Off** option was added — `None` was already a real "do nothing", but Reset now yields left click, so without it there'd be no way to disable a paddle at all.

**Migration:** `BackButtons=1` becomes real bindings, filling in only paddles with no binding of their own, then deleting the value so it runs once.

| Existing state | After upgrade |
|---|---|
| Toggle on, no custom binding | L4/R4 left click — unchanged |
| Toggle on, L4 bound to RT | L4 stays RT, and now actually works |
| Toggle off | Untouched |

Also moved the stuck-button cleanup out of `TrackpadMouse::Reset` into `ReleaseHeldPaddleInputs`, since removing the L4/R4 handling would otherwise have stranded the mouse button down system-wide on teardown.

## 2. Represent paddle bindings as a tagged value, not a flat enum

Groundwork, no behaviour change. A key binding is a value drawn from ~256 virtual-key codes, not a member of a closed set, so `BackButtonAction` had nowhere to put one. `BackButtonBinding` is a kind/code pair covering built-in actions, keys, and extended mouse buttons.

**Both formats extend without a migration**, which is what makes this safe:

- **Registry** — packed as `(kind << 16) | code`. Every value earlier builds wrote is a bare `BackButtonAction` of 0–18, so its kind bits are already zero and it decodes as `Kind::Action`. Action bindings still pack to their bare value, so a *downgrade* also reads settings written by this build.
- **WebView2** — actions keep their bare ids (`"A"`, `"leftMouse"`); open-ended kinds are prefixed (`"key:32"`). Flat strings keep the hand-rolled JSON reader usable, and the JS catalog needed no changes.

Unrecognised values degrade to `None` rather than being applied.

## 3. Allow back paddles to be bound to keyboard keys

Capture happens in the remap page's `keydown` handler, not a keyboard hook — the page is already focused while listening, and a low-level hook is heavy, AV-bait machinery for a convenience feature. The page reports the physical `KeyboardEvent.code`, so a binding made on one layout means the same physical key on another. Keys go out as scan codes rather than virtual keys, since software reading scan codes directly sees nothing useful otherwise.

**A test caught a real bug here.** `MapVirtualKey` is documented to report the `0xE0` extended prefix under `MAPVK_VK_TO_VSC_EX` and does not for the navigation cluster, which shares scan codes with the numpad — Up arrow was being delivered as numpad 8, along with Home/End, PageUp/Down, Insert and Delete. Fixed with an explicit extended-key set.

Labels come from `GetKeyNameText` against the active layout and are JSON-escaped on the way to the page: the backslash key really is named `\`.

Known limits: Escape stays the cancel affordance and isn't bindable; numpad Enter binds as plain Enter (Windows gives them the same VK).

## 4. Repeat held key bindings at the system typematic rate

Holding a paddle bound to a letter produced exactly one character. Auto-repeat isn't something Windows synthesises for a key it believes is down — a physical keyboard repeats because its own firmware keeps sending make codes. Injected input has no firmware behind it, so the repeat is generated here, using the user's own `SPI_GETKEYBOARDDELAY` and `SPI_GETKEYBOARDSPEED` rather than a rate invented in code.

Keys only — mice don't repeat when held, and gamepad bindings are held state in the pad report.

---

## Testing

Commit 1 verified on hardware. Commits 2–4 verified on hardware plus standalone tests over the full value space: legacy registry decoding for all 19 actions, pack and id round-trips for every kind, malformed-input rejection, the JS-code to VK mapping, extended-key separation, and repeat timing bounds.

**Caveat worth carrying forward:** injected keystrokes don't reach every game — anti-cheat and some input paths ignore them — so keyboard bindings are realistically a desktop, emulator, and browser feature. Gamepad bindings remain the answer in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)