### PR TITLE
Allow back paddles to be bound to middle and thumb mouse buttons

### DIFF
--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -308,9 +308,28 @@ static bool SendPaddleInput(const BackButtonBinding& binding, bool down) {
         SendKeyInput(binding.code, down);
         return true;
 
-    case BackButtonBinding::Kind::MouseButton:
-        // Extended mouse buttons are not bindable yet.
-        return false;
+    case BackButtonBinding::Kind::MouseButton: {
+        INPUT inp{};
+        inp.type = INPUT_MOUSE;
+        switch (static_cast<BackButtonBinding::MouseButtonCode>(binding.code)) {
+        case BackButtonBinding::MouseButtonCode::Middle:
+            inp.mi.dwFlags = down ? MOUSEEVENTF_MIDDLEDOWN : MOUSEEVENTF_MIDDLEUP;
+            break;
+        // The thumb buttons share one event pair and are told apart by mouseData.
+        case BackButtonBinding::MouseButtonCode::X1:
+            inp.mi.dwFlags   = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
+            inp.mi.mouseData = XBUTTON1;
+            break;
+        case BackButtonBinding::MouseButtonCode::X2:
+            inp.mi.dwFlags   = down ? MOUSEEVENTF_XDOWN : MOUSEEVENTF_XUP;
+            inp.mi.mouseData = XBUTTON2;
+            break;
+        default:
+            return false;
+        }
+        SendInput(1, &inp, sizeof(INPUT));
+        return true;
+    }
 
     case BackButtonBinding::Kind::Action:
         if (binding.IsAction(BackButtonAction::LeftMouseButton)) {

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -105,7 +105,7 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 <div id="body">
   <div>
     <h2>Back Button Mapping</h2>
-    <p class="instr">Click <b>Rebind</b> on a button, then press any gamepad button on your controller &#8212; or any key on your keyboard. The new binding shows up here instantly. Pick <b>Off</b> to stop a paddle doing anything at all.</p>
+    <p class="instr">Click <b>Rebind</b> on a button, then press any gamepad button on your controller &#8212; or any key on your keyboard, or your mouse's middle or thumb buttons. The new binding shows up here instantly. Pick <b>Off</b> to stop a paddle doing anything at all.</p>
   </div>
   <div class="group">
     <div class="group-label">LEFT GRIP</div>
@@ -125,7 +125,12 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
     <button class="btn-apply" id="btn-apply">Apply</button>
   </div>
 </div>
-
+)HTML"
+// Split here only to stay under MSVC's ~16KB limit on a single string literal
+// (C2026); the two halves are concatenated back into one document. Markup and
+// styles above, script below — keep any new content on whichever side is
+// smaller rather than rejoining these.
+R"HTML(
 <script>
 'use strict';
 // ---- Defaults (upper paddles left-click, lower paddles unbound) ----
@@ -158,6 +163,9 @@ var INPUTS = [
   {id:'Right',     glyph:'&#x2192;', label:'D-Pad Right', bg:'#2a3f57',fg:'#cdd9e3'},
   {id:'leftMouse', glyph:'LMB',     label:'Left Click',  bg:'#3a2a5a',fg:'#c9b8f0'},
   {id:'rightMouse',glyph:'RMB',     label:'Right Click', bg:'#3a2a5a',fg:'#c9b8f0'},
+  {id:'mouse:middle',glyph:'MMB',   label:'Middle Click',bg:'#3a2a5a',fg:'#c9b8f0'},
+  {id:'mouse:x1',  glyph:'M4',      label:'Mouse 4',     bg:'#3a2a5a',fg:'#c9b8f0'},
+  {id:'mouse:x2',  glyph:'M5',      label:'Mouse 5',     bg:'#3a2a5a',fg:'#c9b8f0'},
   {id:'menu',      glyph:'MNU',     label:'Menu',        bg:'#2a3a2a',fg:'#9ac89a'},
   {id:'view',      glyph:'VEW',     label:'View',        bg:'#2a3a2a',fg:'#9ac89a'},
   {id:'L3',        glyph:'L3',      label:'L3 Stick',    bg:'#37485a',fg:'#cdd9e3'},
@@ -172,7 +180,8 @@ var PICKER_ROWS = [
   ['A','B','X','Y'],
   ['LB','LT','RB','RT'],
   ['Up','Down','Left','Right'],
-  ['L3','R3','menu','view','leftMouse','rightMouse'],
+  ['L3','R3','menu','view'],
+  ['leftMouse','rightMouse','mouse:middle','mouse:x1','mouse:x2'],
   ['none'],
 ];
 
@@ -270,7 +279,7 @@ function renderRow(def){
   var rightHTML;
   if(isL){
     rightHTML='<div class="listen-right">'+
-      '<span class="listen-pill"><span class="pulse-dot"></span>Press a button or key...</span>'+
+      '<span class="listen-pill"><span class="pulse-dot"></span>Press a button, key, or mouse button...</span>'+
       '<button class="btn-row-reset" onclick="resetRow(\''+def.id+'\')">Reset</button>'+
       '<button class="btn-cancel" onclick="cancelListening()">&#10005;</button>'+
       '</div>';
@@ -321,6 +330,25 @@ document.getElementById('titlebar').addEventListener('mousedown',function(e){
   if(e.target.closest('.winctls')) return;
   if(e.button!==0) return;
   postMsg({type:'startDrag'});
+});
+
+// Middle and the two thumb buttons can be captured by pressing them, because
+// none of them is needed to operate this window. Left and right deliberately
+// cannot — the user has to keep clicking Rebind and Cancel — so they stay
+// available from the picker below instead.
+var MOUSE_CAPTURE = {1:'mouse:middle', 3:'mouse:x1', 4:'mouse:x2'};
+document.addEventListener('mousedown',function(e){
+  if(!listening) return;
+  var id=MOUSE_CAPTURE[e.button];
+  if(!id) return;
+  // Suppress the browser defaults these carry: autoscroll on middle, and
+  // history navigation on the thumb buttons.
+  e.preventDefault();
+  e.stopPropagation();
+  postMsg({type:'mouseCaptured',button:id});
+});
+document.addEventListener('auxclick',function(e){
+  if(listening&&MOUSE_CAPTURE[e.button]) e.preventDefault();
 });
 
 document.addEventListener('keydown',function(e){
@@ -712,6 +740,13 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
                 PostMessageW(hwnd, WM_BUTTON_CAPTURED,
                              static_cast<WPARAM>(binding.Pack()), 0);
             });
+        }
+
+    } else if (type == "mouseCaptured") {
+        const BackButtonBinding binding = BackButtonBinding::FromId(JsonStr(msg, "button"));
+        if (binding.kind == BackButtonBinding::Kind::MouseButton) {
+            if (m_mgr) m_mgr->StopButtonCapture();
+            PostCapturedBinding(binding);
         }
 
     } else if (type == "keyCaptured") {


### PR DESCRIPTION
Completes the binding work started in #57. `Kind::MouseButton` was reserved for these in the refactor but had no emission arm and no way to pick one, so **middle click, Mouse 4, and Mouse 5 were unbindable by any route**. This wires up both ends.

## Capture is deliberately asymmetric

Middle and the two thumb buttons can be bound by *pressing* them while a row is listening, because none of them is needed to operate the remap window.

**Left and right still can't be captured** — you have to keep clicking *Rebind* and *Cancel* while a row listens, so capturing them would make the window unusable. They stay pickable from the catalog, exactly as before.

Capture suppresses the browser behaviours these buttons carry: autoscroll on middle, history navigation on the thumb buttons.

## Build note worth carrying forward

Adding three catalog entries pushed the remap window's HTML past **MSVC's ~16KB limit for a single string literal** (C2026) — it was already sitting at ~16.5KB. That's a hard build failure rather than a silent truncation, so it can't slip through unnoticed.

Split into two concatenated literals at the `<script>` boundary (8.0KB markup+CSS / 9.3KB script), with a comment so the halves don't get helpfully rejoined. The reassembled document was verified at the junction and for tag balance (27/27 divs, one each of `head`/`style`/`body`/`script`).

## Testing

Verified on hardware: binding by press and from the picker, middle click opening a link in a new tab, Mouse 4/5 driving browser back/forward, and no stuck button when a bound paddle is held while the app exits. These flow through the same held-input tracking added in #57 and correctly do not auto-repeat — real mice don't repeat when held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)