### PR TITLE
Bump installer version to 1.13

### DIFF
--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.11"
+#define MyAppVersion "1.13"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"


### PR DESCRIPTION
Version bump for the release carrying #59 (blocked-input detection and the tray warning).

Note: 1.12 was cut from a working-tree edit that was never committed, so it has no commit of its own and the version history steps 1.11 → 1.13. The released 1.12 build carried the same code as 1.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)