### PR TITLE
Put back a controller devnode left disabled by an unfinished cycle

### DIFF
--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.13"
+#define MyAppVersion "1.14"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/src/app/DeviceRestart.cpp
+++ b/src/app/DeviceRestart.cpp
@@ -2,6 +2,10 @@
 #include <SetupAPI.h>
 #include <cfgmgr32.h>
 #include <cstdio>
+#include <io.h>
+#include <shlwapi.h>
+#include <vector>
+#pragma comment(lib, "shlwapi.lib")
 
 namespace DeviceRestart {
 
@@ -133,6 +137,25 @@ static RemoveOutcome QueryRemoveAndRestore(DEVINST devInst, CycleResult& out) {
 // getting that wrong strands the controller switched off, needing Device
 // Manager to recover, which is far worse than failing to cycle at all.
 static void CycleDevNode(HDEVINFO devs, SP_DEVINFO_DATA& devInfo, CycleResult& out) {
+    // Write down what is about to be switched off, before switching it off. A
+    // global disable lands in the registry immediately and survives this
+    // process, so from here until the re-enable is confirmed there is a window
+    // in which dying strands the device. The record is what closes it.
+    //
+    // The parent goes in alongside the node itself because the disable does not
+    // reliably land where it is aimed: measured on the wired SC2026, disabling
+    // the HID collection child left CONFIGFLAG_DISABLED on the USB parent
+    // instead. Recording both costs nothing and makes recovery independent of
+    // which node Windows actually marks.
+    wchar_t instanceId[MAX_DEVICE_ID_LEN] = {};
+    CM_Get_Device_IDW(devInfo.DevInst, instanceId, ARRAYSIZE(instanceId), 0);
+
+    wchar_t parentId[MAX_DEVICE_ID_LEN] = {};
+    if (DEVINST parent = 0; CM_Get_Parent(&parent, devInfo.DevInst, 0) == CR_SUCCESS)
+        CM_Get_Device_IDW(parent, parentId, ARRAYSIZE(parentId), 0);
+
+    ArmPendingDisable(instanceId, parentId);
+
     // Some devices reject a global scope change and only accept a
     // config-specific one, so try both before believing a disable was refused.
     if (!SetDeviceState(devs, devInfo, DICS_DISABLE, DICS_FLAG_GLOBAL))
@@ -158,11 +181,15 @@ static void CycleDevNode(HDEVINFO devs, SP_DEVINFO_DATA& devInfo, CycleResult& o
 
     if (!enabled) {
         // The controller is stranded disabled — the caller must surface this,
-        // it is not a quiet failure.
+        // it is not a quiet failure. The pending record deliberately stays
+        // armed: this is exactly the state the next run has to clean up.
         out.kind  = CycleKind::Failed;
         out.error = GetLastError();
         return;
     }
+
+    // Confirmed back. Nothing left for a later run to undo.
+    DisarmPendingDisable();
 
     if (wentDown) {
         out.kind = CycleKind::Cycled;
@@ -300,6 +327,163 @@ bool ReadCycleStatus(CycleResult& result) {
     }
     fclose(f);
     return true;
+}
+
+// ---------------------------------------------------------------------------
+// Crash-safe disable
+// ---------------------------------------------------------------------------
+
+static std::wstring PendingPath() {
+    wchar_t local[MAX_PATH];
+    if (!GetEnvironmentVariableW(L"LOCALAPPDATA", local, MAX_PATH)) return L"";
+    const std::wstring dir = std::wstring(local) + L"\\SteamlessController";
+    CreateDirectoryW(dir.c_str(), nullptr);
+    return dir + L"\\pending-disable";
+}
+
+bool ArmPendingDisable(const std::wstring& instanceId,
+                       const std::wstring& parentInstanceId) {
+    const std::wstring path = PendingPath();
+    if (path.empty() || instanceId.empty()) return false;
+
+    FILE* f = nullptr;
+    if (_wfopen_s(&f, path.c_str(), L"w, ccs=UTF-8") != 0 || !f) return false;
+
+    // Outermost node first: reconciliation walks the file in order, and a
+    // disabled parent has to come back before its child can be looked at.
+    if (!parentInstanceId.empty())
+        fwprintf(f, L"%s\n", parentInstanceId.c_str());
+    fwprintf(f, L"%s\n", instanceId.c_str());
+
+    // The whole point of this file is to outlive an abrupt death, so it has to
+    // reach the disk before the disable it is guarding — buffered in this
+    // process is no better than not written at all.
+    fflush(f);
+    _commit(_fileno(f));
+    fclose(f);
+    return true;
+}
+
+bool DisarmPendingDisable() {
+    const std::wstring path = PendingPath();
+    if (path.empty()) return false;
+    return DeleteFileW(path.c_str()) || GetLastError() == ERROR_FILE_NOT_FOUND;
+}
+
+static std::vector<std::wstring> ReadPendingIds() {
+    std::vector<std::wstring> ids;
+    const std::wstring path = PendingPath();
+    if (path.empty()) return ids;
+
+    FILE* f = nullptr;
+    if (_wfopen_s(&f, path.c_str(), L"r, ccs=UTF-8") != 0 || !f) return ids;
+
+    wchar_t line[MAX_DEVICE_ID_LEN + 2];
+    while (fgetws(line, ARRAYSIZE(line), f)) {
+        size_t len = wcslen(line);
+        while (len && (line[len - 1] == L'\n' || line[len - 1] == L'\r'))
+            line[--len] = L'\0';
+        if (len) ids.emplace_back(line);
+    }
+    fclose(f);
+    return ids;
+}
+
+bool HasPendingDisable() {
+    return !ReadPendingIds().empty();
+}
+
+// Bring one devnode back, addressed by instance ID rather than by an interface
+// path — the interfaces are gone while the node is disabled, so the path that
+// started the cycle cannot be used to finish it.
+static bool EnableByInstanceId(const std::wstring& id, bool& wasDisabled) {
+    wasDisabled = false;
+
+    DEVINST devInst = 0;
+    // PHANTOM rather than NORMAL: the node may not be started, which is the
+    // entire situation being repaired.
+    if (CM_Locate_DevNodeW(&devInst, const_cast<DEVINSTID_W>(id.c_str()),
+                           CM_LOCATE_DEVNODE_PHANTOM) != CR_SUCCESS)
+        return false;
+    if (!IsDevNodeDisabled(devInst)) return false;
+    wasDisabled = true;
+
+    HDEVINFO devs = SetupDiCreateDeviceInfoList(nullptr, nullptr);
+    if (devs == INVALID_HANDLE_VALUE) return false;
+
+    bool enabled = false;
+    SP_DEVINFO_DATA devInfo{};
+    devInfo.cbSize = sizeof(devInfo);
+    if (SetupDiOpenDeviceInfoW(devs, id.c_str(), nullptr, 0, &devInfo)) {
+        for (int attempt = 0; attempt < 3 && !enabled; ++attempt) {
+            if (attempt) Sleep(500);
+            SetDeviceState(devs, devInfo, DICS_ENABLE, DICS_FLAG_GLOBAL);
+            if (IsDevNodeDisabled(devInfo.DevInst))
+                SetDeviceState(devs, devInfo, DICS_ENABLE, DICS_FLAG_CONFIGSPECIFIC);
+            enabled = !IsDevNodeDisabled(devInfo.DevInst);
+        }
+    }
+    SetupDiDestroyDeviceInfoList(devs);
+    return enabled;
+}
+
+int ReconcilePendingDisables(std::wstring* report) {
+    const std::vector<std::wstring> ids = ReadPendingIds();
+    if (ids.empty()) return 0;
+
+    int recovered = 0;
+    std::wstring text;
+    for (const auto& id : ids) {
+        bool wasDisabled = false;
+        const bool ok = EnableByInstanceId(id, wasDisabled);
+        if (!wasDisabled) continue;  // came back on its own, or never went down
+
+        if (ok) ++recovered;
+        if (!text.empty()) text += L"; ";
+        text += id + (ok ? L" -> re-enabled" : L" -> STILL DISABLED");
+    }
+
+    // Drop the record either way. A node that could not be re-enabled here will
+    // not be re-enabled by trying again on the next launch, and keeping the
+    // file would turn one stranded device into a permanent startup ritual —
+    // the failure is surfaced through the log instead.
+    DisarmPendingDisable();
+
+    if (report) *report = text;
+    return recovered;
+}
+
+std::wstring FindDisabledControllerNode() {
+    // Every enumerator the controller can appear under. HID matters most and is
+    // the easiest to forget: a cycle disables the HID collection child, so that
+    // is the node most likely to be found switched off — its USB parent sits
+    // one level up and stays perfectly healthy. Non-present nodes are included
+    // deliberately, since a disabled devnode is exactly the case where the
+    // device is attached but not started.
+    for (const wchar_t* enumerator : { L"HID", L"USB", L"BTHLEDEVICE", L"BTHENUM" }) {
+        ULONG len = 0;
+        if (CM_Get_Device_ID_List_SizeW(&len, enumerator,
+                                        CM_GETIDLIST_FILTER_ENUMERATOR) != CR_SUCCESS
+            || len < 2)
+            continue;
+
+        std::vector<wchar_t> buf(len);
+        if (CM_Get_Device_ID_ListW(enumerator, buf.data(), len,
+                                   CM_GETIDLIST_FILTER_ENUMERATOR) != CR_SUCCESS)
+            continue;
+
+        for (const wchar_t* id = buf.data(); *id; id += wcslen(id) + 1) {
+            // Valve's vendor ID, however the enumerator spells the token.
+            if (!StrStrIW(id, L"VID_28DE") && !StrStrIW(id, L"VID&0228DE")) continue;
+
+            DEVINST devInst = 0;
+            if (CM_Locate_DevNodeW(&devInst, const_cast<DEVINSTID_W>(id),
+                                   CM_LOCATE_DEVNODE_PHANTOM) != CR_SUCCESS)
+                continue;
+            if (IsDevNodeDisabled(devInst)) return id;
+        }
+    }
+    return L"";
 }
 
 }

--- a/src/app/DeviceRestart.h
+++ b/src/app/DeviceRestart.h
@@ -83,4 +83,51 @@ bool RestartInterfaceDevice(const std::wstring& interfacePath, CycleResult& resu
 bool WriteCycleStatus(const CycleResult& result);
 bool ReadCycleStatus(CycleResult& result);
 
+// ---------------------------------------------------------------------------
+// Crash-safe disable
+// ---------------------------------------------------------------------------
+//
+// A global disable is written straight into the devnode's registry ConfigFlags,
+// so it outlives the process that asked for it — and a reboot, and a replug.
+// The re-enable that undoes it lives a second or so later in the same function,
+// which is fine right up until the process does not survive that second.
+//
+// That is not hypothetical: a cycle on the elevated in-process path runs inside
+// the long-lived tray app, and killing it mid-cycle strands the controller
+// switched off with nothing left running to put it back. Recovering needs
+// Device Manager, which is not something a user should have to discover.
+//
+// So the intent to disable is recorded durably *before* the disable, and
+// cleared only once the devnode confirms it is back. Anything left behind is a
+// cycle that did not finish, and the next run undoes it.
+
+// Record that these devnodes are about to be disabled. Call immediately before
+// the disable; the record is flushed to disk before this returns.
+bool ArmPendingDisable(const std::wstring& instanceId,
+                       const std::wstring& parentInstanceId);
+
+// Drop the record. Call only once the devnode is confirmed enabled again.
+bool DisarmPendingDisable();
+
+// True when a previous run left a disable unfinished. Cheap; safe unelevated.
+bool HasPendingDisable();
+
+// Re-enable whatever a previous run left disabled, then drop the record.
+// Requires elevation — the tray app routes this through the helper.
+// Returns the number of devnodes actually brought back; `report` receives a
+// human-readable summary for the event log.
+int ReconcilePendingDisables(std::wstring* report = nullptr);
+
+// Any Valve controller devnode sitting in CM_PROB_DISABLED, whoever switched it
+// off — us, Device Manager, or a tool that hides HID devices. Returns an empty
+// string when nothing is disabled.
+//
+// A disabled devnode publishes no interfaces, so from inside this app it is
+// indistinguishable from a controller that was never plugged in: enumeration
+// simply returns nothing. That is a bad thing to be silent about, because the
+// device still lights up and still makes Windows chime when it is plugged in,
+// so the user has every reason to believe it is fine and we are broken.
+// Read-only and safe unelevated.
+std::wstring FindDisabledControllerNode();
+
 }

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -126,6 +126,17 @@ bool TrayApp::Init(HINSTANCE hInstance) {
     if (m_autoMode == AutoMode::OffOnlyInGame)
         EnsureCycleTaskRegistered();
 
+    // Deliberately last, and every part of that ordering is load-bearing: it
+    // reports through the tray balloon, which does nothing until AddTrayIcon has
+    // run; it honours the notification setting, which LoadSettings supplies; and
+    // it may need the elevated helper, so it goes after the task registration
+    // above rather than raising a second UAC prompt of its own.
+    //
+    // Nothing earlier needs the controller to exist. A device brought back here
+    // announces itself as an ordinary DBT_DEVICEARRIVAL once the message loop
+    // starts, and is picked up on that path like any other replug.
+    RecoverStrandedDevices();
+
     // Start watching for Steam regardless of auto mode — the state is applied
     // only when auto mode is on, and having it warm makes toggling auto mode
     // take effect instantly. The initial callback asserts the correct state
@@ -160,9 +171,13 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 
     switch (msg) {
     case WM_TRAY:
-        if (LOWORD(lp) == NIN_BALLOONUSERCLICK)
-            ShellExecuteW(nullptr, L"open", L"https://github.com/nefarius/ViGEmBus/releases/latest",
-                          nullptr, nullptr, SW_SHOWNORMAL);
+        if (LOWORD(lp) == NIN_BALLOONUSERCLICK) {
+            if (m_balloonAction == BalloonAction::EnableDisabledDevice)
+                EnableDisabledControllerDevice();
+            else
+                ShellExecuteW(nullptr, L"open", L"https://github.com/nefarius/ViGEmBus/releases/latest",
+                              nullptr, nullptr, SW_SHOWNORMAL);
+        }
         else if (LOWORD(lp) == WM_LBUTTONDBLCLK)
             OpenRemapWindow();
         else if (LOWORD(lp) == WM_RBUTTONUP || LOWORD(lp) == WM_LBUTTONUP)
@@ -233,6 +248,9 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             EventLog::Write("USER: disconnect notifications %s",
                             m_notificationsEnabled ? "enabled" : "disabled");
             SaveSettings();
+            break;
+        case IDM_ENABLE_DEVICE:
+            EnableDisabledControllerDevice();
             break;
         case IDM_EXIT:
             EventLog::Write("=== SteamlessController exiting (user request) ===");
@@ -358,8 +376,13 @@ void TrayApp::ReleaseControl() {
     // Steam only (re)opens controllers on device-arrival events. If it is
     // already running and we held the device, it never saw one — cycle
     // the device so Steam adopts it immediately.
-    if (hadControl && m_steamWatcher.GetState() != SteamState::NoSteam)
+    if (hadControl && m_steamWatcher.GetState() != SteamState::NoSteam) {
+        // Logged because this cycle is otherwise invisible. The acquire path
+        // announces itself; this one used to not, which made a device left
+        // disabled by an interrupted release look like it came from nowhere.
+        EventLog::Write("RELEASE: cycling device so Steam sees an arrival");
         RestartControllerDevices();
+    }
 }
 
 void TrayApp::TryAcquireController(uint32_t stateWaitMs) {
@@ -536,6 +559,97 @@ void TrayApp::ReportAcquireFailure() {
                          L"Closing Steam will hand it back.");
 }
 
+bool TrayApp::RunPendingRecovery() {
+    if (IsProcessElevated()) {
+        std::wstring report;
+        const int recovered = DeviceRestart::ReconcilePendingDisables(&report);
+        EventLog::Write("RECOVER: %ls (%d devnode(s) re-enabled)",
+                        report.empty() ? L"nothing was still disabled" : report.c_str(),
+                        recovered);
+        return true;
+    }
+
+    // Enabling a devnode needs elevation, so this has to go through the helper.
+    // Its scheduled task takes no arguments — schtasks cannot pass any — so it
+    // runs the ordinary entry point, which reconciles first and then cycles.
+    // Both are wanted here: the device comes back, and it comes back presented
+    // as a fresh arrival that Steam and we can race for as usual.
+    //
+    // Asynchronous: schtasks returns once the task has been started, not once
+    // the helper has finished, so the device reappears on its own a moment later
+    // as a normal arrival rather than before this returns.
+    return RestartControllerDevices();
+}
+
+// Undo a disable an earlier run committed to the registry but never reversed.
+// Cheap and silent in the normal case: with no pending record this is one
+// failed file open.
+void TrayApp::RecoverStrandedDevices() {
+    if (!DeviceRestart::HasPendingDisable()) {
+        // No record of our own, but the device can still be switched off — by
+        // Device Manager, by regedit, by pnputil, by a tool that hides HID
+        // devices. Not something to undo silently: it may well be deliberate.
+        // Naming it is the useful part, because from here it is otherwise
+        // indistinguishable from no controller being plugged in at all.
+        m_disabledDeviceNode = DeviceRestart::FindDisabledControllerNode();
+        if (!m_disabledDeviceNode.empty()) {
+            EventLog::Write("STARTUP: a controller devnode is disabled in Windows, so it "
+                            "publishes no interfaces and cannot be seen here or by Steam: "
+                            "%ls", m_disabledDeviceNode.c_str());
+            EventLog::Write("STARTUP: re-enable it from the tray menu, in Device Manager, "
+                            "or with: pnputil /enable-device \"%ls\"",
+                            m_disabledDeviceNode.c_str());
+            if (m_notificationsEnabled)
+                ShowAlertBalloon(L"Controller is disabled in Windows",
+                                 L"Windows has this controller's device switched off, so "
+                                 L"nothing can see it — including Steam. Click here to "
+                                 L"re-enable it.",
+                                 BalloonAction::EnableDisabledDevice);
+        }
+        return;
+    }
+
+    EventLog::Write("RECOVER: a previous run was interrupted mid-cycle and left the "
+                    "controller's devnode disabled — putting it back");
+
+    if (!RunPendingRecovery())
+        EventLog::Write("RECOVER: the elevated helper could not be run — the controller "
+                        "stays disabled until it is re-enabled in Device Manager "
+                        "(or: pnputil /enable-device \"<instance id>\")");
+}
+
+void TrayApp::EnableDisabledControllerDevice() {
+    // Re-resolve rather than trusting what the menu or balloon was built from:
+    // minutes may have passed, and the user may already have fixed it by hand.
+    const std::wstring node = DeviceRestart::FindDisabledControllerNode();
+    m_disabledDeviceNode = node;
+    if (node.empty()) {
+        EventLog::Write("USER: asked to re-enable the controller device, but no controller "
+                        "devnode is disabled");
+        return;
+    }
+
+    EventLog::Write("USER: re-enabling disabled controller devnode %ls", node.c_str());
+
+    // Hand it to the same mechanism that repairs an interrupted cycle rather
+    // than growing a second way to switch a devnode on: recorded as pending, it
+    // is undone by exactly the path that has already been exercised. The parent
+    // is left blank — this node is known to be the disabled one, so there is
+    // nothing to guess at.
+    DeviceRestart::ArmPendingDisable(node, L"");
+
+    if (!RunPendingRecovery()) {
+        EventLog::Write("USER: could not run the elevated helper to re-enable the device");
+        if (m_notificationsEnabled)
+            ShowAlertBalloon(L"Could not re-enable the controller",
+                             L"Windows would not let the device be switched back on from "
+                             L"here. Re-enable it in Device Manager, under Human Interface "
+                             L"Devices.");
+        return;
+    }
+    m_disabledDeviceNode.clear();
+}
+
 bool TrayApp::RestartControllerDevices() {
     // On the rare elevated run, cycle directly. This works on every transport
     // including Bluetooth: the devnode being restarted is the HID child, not
@@ -645,7 +759,10 @@ void TrayApp::UpdateTrayIcon(bool connected, bool gameModeActive, bool vigemMiss
     Shell_NotifyIconW(NIM_MODIFY, &nid);
 }
 
-void TrayApp::ShowAlertBalloon(const std::wstring& title, const std::wstring& text) {
+void TrayApp::ShowAlertBalloon(const std::wstring& title, const std::wstring& text,
+                              BalloonAction action) {
+    m_balloonAction = action;
+
     NOTIFYICONDATAW nid{};
     nid.cbSize      = sizeof(nid);
     nid.hWnd        = m_hwnd;
@@ -948,6 +1065,18 @@ void TrayApp::ShowContextMenu() {
     bool startupOn    = m_startupEnabled;
 
     HMENU menu = CreatePopupMenu();
+
+    // Only present when it applies, and first when it does: with the devnode
+    // switched off nothing else on this menu can do anything useful, and every
+    // other entry will be reporting "no controller detected" for a reason the
+    // user has no way to guess at. Re-resolved on each open so it disappears
+    // once the device is back, however it got there.
+    m_disabledDeviceNode = DeviceRestart::FindDisabledControllerNode();
+    if (!m_disabledDeviceNode.empty()) {
+        AppendMenuW(menu, MF_STRING, IDM_ENABLE_DEVICE,
+                    L"Re-enable Controller Device (disabled in Windows)");
+        AppendMenuW(menu, MF_SEPARATOR, 0, nullptr);
+    }
 
     // Manual toggle is disabled while an auto mode owns the decision — when
     // grayed, the label itself says why.

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -90,6 +90,9 @@ bool TrayApp::Init(HINSTANCE hInstance) {
 
     EventLog::Write("=== SteamlessController started ===");
 
+    m_startTick = GetTickCount64();
+    QueryUnbiasedInterruptTime(&m_lastHeartbeatUnbiased);
+
     m_controller = std::make_unique<ControllerManager>(
         [this](bool connected, bool gameModeActive, bool vigemMissing) {
             UpdateTrayIcon(connected, gameModeActive, vigemMissing);
@@ -136,6 +139,11 @@ bool TrayApp::Init(HINSTANCE hInstance) {
     // announces itself as an ordinary DBT_DEVICEARRIVAL once the message loop
     // starts, and is picked up on that path like any other replug.
     RecoverStrandedDevices();
+
+    // Runs for the life of the process in every mode. Nothing here depends on
+    // it, which is the point: it exists so that the log can tell "idle" from
+    // "stopped" without anyone having to reproduce the fault.
+    SetTimer(m_hwnd, IDT_HEARTBEAT, HEARTBEAT_MS, nullptr);
 
     // Start watching for Steam regardless of auto mode — the state is applied
     // only when auto mode is on, and having it warm makes toggling auto mode
@@ -293,6 +301,9 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             // Cheap probe — we are only asking whether anything woke up.
             if (m_wantControl)
                 TryAcquireController(WAKE_PROBE_MS);
+        } else if (wp == IDT_HEARTBEAT) {
+            // Periodic, so not killed — its absence is the signal.
+            WriteHeartbeat();
         } else if (wp == IDT_ACQUIRE_VERDICT) {
             KillTimer(m_hwnd, IDT_ACQUIRE_VERDICT);
             // The last cycle's re-arrival had a grace period to land. If it
@@ -579,6 +590,45 @@ bool TrayApp::RunPendingRecovery() {
     // the helper has finished, so the device reappears on its own a moment later
     // as a normal arrival rather than before this returns.
     return RestartControllerDevices();
+}
+
+// A silent log is ambiguous. Nothing is written while the app sits idle with
+// nothing changing — AUTO lines only fire on Steam state *changes* — and
+// nothing is written while it is wedged or dead either. So a gap means either
+// "healthy, with nothing to say" or "stopped working", and after the fact there
+// is no way to tell which. That ambiguity cost a real investigation: 33 hours
+// of silence that read as a hang and was very likely an idle app.
+//
+// Driven by the window timer deliberately. A background thread would only prove
+// the process still exists; this proves the message loop is still being pumped,
+// which is what "not hung" means here — the acquire and release paths both run
+// on it, and both can sit inside SetupAPI for seconds at a time.
+void TrayApp::WriteHeartbeat() {
+    ULONGLONG unbiased = 0;
+    QueryUnbiasedInterruptTime(&unbiased);
+    const ULONGLONG sinceMs = m_lastHeartbeatUnbiased
+        ? (unbiased - m_lastHeartbeatUnbiased) / 10000ULL
+        : 0;
+    m_lastHeartbeatUnbiased = unbiased;
+
+    // Unbiased time does not advance while the machine is suspended, so a beat
+    // that is late by this measure was genuinely blocked rather than closed in
+    // a laptop lid. Worth its own line: a stall that recovers leaves no other
+    // trace, and the beat before a gap is the last sign of life anyone gets.
+    if (sinceMs > HEARTBEAT_MS + HEARTBEAT_SLACK_MS)
+        EventLog::Write("HEARTBEAT: the message loop was blocked for %llu s "
+                        "(beat due every %u s)",
+                        sinceMs / 1000, HEARTBEAT_MS / 1000);
+
+    const ULONGLONG upMs = GetTickCount64() - m_startTick;
+    EventLog::Write("HEARTBEAT: alive uptime=%lluh%02llum controller=%s gameMode=%s "
+                    "steam=%d (0=none 1=idle 2=inGame) mode=%d wantControl=%d",
+                    upMs / 3600000ULL, (upMs / 60000ULL) % 60ULL,
+                    m_controller->IsConnected() ? "connected" : "absent",
+                    m_controller->IsGameModeActive() ? "on" : "off",
+                    static_cast<int>(m_steamWatcher.GetState()),
+                    static_cast<int>(m_autoMode),
+                    m_wantControl ? 1 : 0);
 }
 
 // Undo a disable an earlier run committed to the registry but never reversed.

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -66,6 +66,7 @@ private:
     void TryAcquireController(uint32_t stateWaitMs = 250);
     void ReleaseControl();
     void RecoverStrandedDevices();
+    void WriteHeartbeat();
     // Carry out whatever the pending-disable record asks for: in process when
     // elevated, through the helper's task otherwise. Shared so there is one
     // place that knows how to get a devnode switched back on.
@@ -100,6 +101,11 @@ private:
     int                                m_startupMechanism = 0;  // 0 none, 1 Run key, 2 elevated task
     bool                               m_notificationsEnabled = true;  // disconnect/stall balloons
     BalloonAction                      m_balloonAction = BalloonAction::ViGEmDownload;
+    // Unbiased interrupt time at the last heartbeat, and the tick this instance
+    // started. Unbiased so that time the machine spent asleep does not read as
+    // the app having been blocked.
+    ULONGLONG                          m_lastHeartbeatUnbiased = 0;
+    ULONGLONG                          m_startTick = 0;
     // Devnode found disabled when the menu was last built, so the command
     // handler and the menu agree on what "re-enable" refers to.
     std::wstring                       m_disabledDeviceNode;
@@ -131,6 +137,16 @@ private:
     static constexpr UINT_PTR IDT_ACQUIRE         = 1;
     static constexpr UINT_PTR IDT_ACQUIRE_VERDICT = 2;
     static constexpr UINT_PTR IDT_WAKE_POLL       = 3;
+    static constexpr UINT_PTR IDT_HEARTBEAT       = 4;
+    // Long enough that idling for a month costs a fraction of the log's 512 KB,
+    // short enough to bound when the app stopped responding to within a
+    // quarter hour. Resolution only has to beat "somewhere in the last 33
+    // hours", which is what the log offered the last time this mattered.
+    static constexpr UINT HEARTBEAT_MS = 15 * 60 * 1000;
+    // Slack before a late beat is called a stall. Window timers are low
+    // priority and coalesced, so a beat is routinely a little late; a full
+    // minute of drift is not.
+    static constexpr UINT HEARTBEAT_SLACK_MS = 60 * 1000;
     // A multi-slot receiver publishes every slot interface permanently, so a
     // controller waking up produces no device-change event — the only way to
     // notice is to keep asking. The probe is short because a live slot streams

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -33,7 +33,13 @@ private:
     void RemoveTrayIcon();
     void UpdateTrayIcon(bool connected, bool gameModeActive, bool vigemMissing = false);
     void ShowViGEmBalloon();
-    void ShowAlertBalloon(const std::wstring& title, const std::wstring& text);
+
+    // What clicking the balloon should do. Balloons are transient and the click
+    // arrives long after the call that raised one, so the action travels with
+    // it rather than being inferred at click time.
+    enum class BalloonAction { ViGEmDownload, EnableDisabledDevice };
+    void ShowAlertBalloon(const std::wstring& title, const std::wstring& text,
+                          BalloonAction action = BalloonAction::ViGEmDownload);
     void OpenEventLog();
     void ShowContextMenu();
     void LoadSettings();
@@ -59,6 +65,13 @@ private:
     void ApplySteamState(SteamState state);
     void TryAcquireController(uint32_t stateWaitMs = 250);
     void ReleaseControl();
+    void RecoverStrandedDevices();
+    // Carry out whatever the pending-disable record asks for: in process when
+    // elevated, through the helper's task otherwise. Shared so there is one
+    // place that knows how to get a devnode switched back on.
+    bool RunPendingRecovery();
+    // User-initiated repair of a devnode this app did not disable.
+    void EnableDisabledControllerDevice();
     bool RestartControllerDevices();
     bool RefreshCycleStatus();
     bool LastCycleBrokeNothing();
@@ -86,6 +99,10 @@ private:
     bool                               m_startupEnabled   = false;
     int                                m_startupMechanism = 0;  // 0 none, 1 Run key, 2 elevated task
     bool                               m_notificationsEnabled = true;  // disconnect/stall balloons
+    BalloonAction                      m_balloonAction = BalloonAction::ViGEmDownload;
+    // Devnode found disabled when the menu was last built, so the command
+    // handler and the menu agree on what "re-enable" refers to.
+    std::wstring                       m_disabledDeviceNode;
     std::mutex                         m_alertMutex;   // guards the two alert strings
     std::wstring                       m_alertTitle;   // set on read threads,
     std::wstring                       m_alertText;    // consumed on WM_ALERT
@@ -106,6 +123,7 @@ private:
     static constexpr UINT IDM_MODE_GAME     = 1012;
     static constexpr UINT IDM_OPENLOG       = 1013;
     static constexpr UINT IDM_NOTIFICATIONS = 1014;
+    static constexpr UINT IDM_ENABLE_DEVICE = 1015;
     static constexpr UINT WM_TRAY           = WM_APP + 1;
     static constexpr UINT WM_STEAMSTATE     = WM_APP + 2;
     static constexpr UINT WM_ALERT          = WM_APP + 3;

--- a/src/helper/DeviceCycleHelper.cpp
+++ b/src/helper/DeviceCycleHelper.cpp
@@ -9,6 +9,8 @@
 //
 // Usage:
 //   SteamlessDeviceCycle.exe               cycle the controller devices
+//   SteamlessDeviceCycle.exe --reconcile   re-enable a devnode left disabled
+//                                          by an interrupted cycle (admin)
 //   SteamlessDeviceCycle.exe --register    create the on-demand scheduled
 //                                          task pointing at this exe (admin)
 //   SteamlessDeviceCycle.exe --unregister  delete the task (admin)
@@ -74,7 +76,35 @@ static bool RunToolHidden(std::wstring cmdline) {
     return code == 0;
 }
 
+// Undo a disable that an earlier run committed but never got to reverse.
+// Elevated, like everything else here — the tray app cannot do this itself.
+static int ReconcilePending() {
+    std::wstring report;
+    const int recovered = DeviceRestart::ReconcilePendingDisables(&report);
+    if (report.empty()) return 0;  // nothing was pending, or it recovered itself
+
+    CycleLog("RECONCILE: %ls", report.c_str());
+    // A device left switched off is the failure this whole mechanism exists to
+    // prevent, so say so loudly rather than exiting quietly.
+    if (report.find(L"STILL DISABLED") != std::wstring::npos) {
+        CycleLog("RECONCILE: a devnode could not be re-enabled — it needs "
+                 "Device Manager, or pnputil /enable-device");
+        return 1;
+    }
+    // Deliberately not "from an interrupted cycle": the same record is written
+    // when the user asks for a disabled device to be switched back on, and from
+    // here the two are indistinguishable.
+    CycleLog("RECONCILE: recovered %d devnode(s) left disabled", recovered);
+    return 0;
+}
+
 static int CycleDevices() {
+    // An interrupted cycle leaves the controller switched off, and a switched
+    // off controller enumerates nothing — so without this the enumeration below
+    // finds no interfaces and the cycle silently does nothing, which looks
+    // exactly like a controller that is simply not plugged in.
+    ReconcilePending();
+
     bool any = false;
     const auto paths = SteamController::EnumerateAll();
     CycleLog("START: %zu interface(s) to cycle", paths.size());
@@ -278,5 +308,6 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR cmdLine, int) {
     if (cmdLine && wcsstr(cmdLine, L"--register"))     return RegisterTask();
     if (cmdLine && wcsstr(cmdLine, L"--unregister"))   return UnregisterTask();
     if (cmdLine && wcsstr(cmdLine, L"--find-holders")) return FindHoldersOnly();
+    if (cmdLine && wcsstr(cmdLine, L"--reconcile"))    return ReconcilePending();
     return CycleDevices();
 }


### PR DESCRIPTION
A device cycle disables the devnode and re-enables it about a second later. The disable is global, so it lands in the registry immediately and outlives the process that asked for it — and a replug, and a reboot. If the process does not survive that second, the controller is left switched off with nothing running to put it back, and recovering it needs Device Manager.

The window is not theoretical. On the elevated path the cycle runs inside the long-lived tray app rather than the second-long helper, so being killed mid-cycle is an ordinary thing for a user to do.

## What changed

- **The intent to disable is recorded before the disable**, committed to disk, and dropped only once the devnode confirms it is back. What is left behind is an unfinished cycle, and the next run undoes it — in process when elevated, through the helper's scheduled task otherwise, since enabling a devnode needs administrator rights. A cycle that ends stranded deliberately leaves its record armed.
- **The helper reconciles before cycling.** A switched-off controller enumerates nothing, so otherwise the cycle finds no interfaces and silently does nothing — indistinguishable from a controller that is not plugged in. Also exposed as `SteamlessDeviceCycle.exe --reconcile`.
- **A devnode disabled by something else is reported, not silently undone** — Device Manager, regedit, `pnputil`, a tool that hides HID devices. It may well be deliberate, so it is named at startup and offered as a tray item rather than changed behind the user's back.
- **The release-path cycle is logged.** It announced nothing at all, so a device left disabled by an interrupted release appeared to come from nowhere; the acquire path has always said what it was doing.

## Verification

Measured against the real device, by ending the helper the instant `ConfigFlags` went to 1.

Polling both devnodes through a normal cycle — this also settles which node the disable actually lands on, which was not obvious from the outside:

```
HID-Col03=0  USB-parent=1  pending=no     stranded state
HID-Col03=0  USB-parent=0  pending=YES    recovery re-enabled the node
HID-Col03=1  USB-parent=0  pending=YES    a cycle disables the HID child
HID-Col03=0  USB-parent=0  pending=no     and puts it back
```

1. **Interrupted cycle recovers on next launch.** Killed mid-disable: `Col03` left in `Error`, record armed with both nodes. Relaunched unelevated — `RECOVER` → reconcile → `CONNECT` in 1.1 s.
2. **External disable is reported, not touched.** Stranded the node, removed the record, relaunched: named in the log and balloon, left alone.
3. **Tray repair works.** `USER: re-enabling disabled controller devnode ...` → `CONNECT` → `BATTERY: 100%` in 1.1 s.

Test 2 caught a real bug during development: `HID` was missing from the enumerator list, so the check missed the very node a cycle disables. Test 3's ordering caught another — `RecoverStrandedDevices()` ran before `AddTrayIcon()`, and `ShowAlertBalloon` uses `Shell_NotifyIconW(NIM_MODIFY, ...)`, which fails silently with no icon added. The balloon would never have appeared. It now runs last in `Init()`, after the tray icon, after `LoadSettings()`, and after the cycle task registration so it cannot raise a UAC prompt of its own.

## Notes

- The pending record lives in `%LOCALAPPDATA%`, so it is per-user: a cycle interrupted under a different Windows account will not be seen.
- Recovery needs the elevated helper. Where its task is not registered (build folder, post-uninstall) it raises the usual one-time UAC prompt; declining leaves the device disabled and says so.
- Reconciliation drops the record even when a node could not be re-enabled — retrying on every launch would turn one stranded device into a permanent startup ritual, so the failure goes to the log instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
