### PR TITLE
Stop the app from cycling the controller to escape its own handle

### DIFF
--- a/src/app/DeviceRestart.cpp
+++ b/src/app/DeviceRestart.cpp
@@ -9,10 +9,20 @@
 
 namespace DeviceRestart {
 
-// How long to let a disable settle before believing it was refused. Only ever
-// spent on the path that is about to conclude "nothing went down", so a device
-// that disables promptly pays none of it.
-static constexpr int   DISABLE_SETTLE_POLLS   = 10;
+// How long to let a disable settle before believing it was refused.
+//
+// ConfigFlags is written well before the devnode admits to being disabled.
+// Measured on a four-slot receiver, the gap between the registry flag landing
+// and the node reporting problem 22 ran from 96 ms to 330 ms across slots on an
+// otherwise idle machine. Judging the disable inside that gap is not a harmless
+// misread — it concludes the disable was refused, skips the re-enable, and
+// clears the pending record, leaving a devnode switched off with the flag
+// already committed and nothing tracking it.
+//
+// So the window is sized for the bad case rather than the measured one. It is
+// only ever spent on the path about to conclude the disable failed; a device
+// that goes down promptly pays none of it.
+static constexpr int   DISABLE_SETTLE_POLLS   = 20;   // ~950 ms
 static constexpr DWORD DISABLE_SETTLE_STEP_MS = 50;
 
 static bool SetDeviceState(HDEVINFO devs, SP_DEVINFO_DATA& devInfo,

--- a/src/app/DeviceRestart.cpp
+++ b/src/app/DeviceRestart.cpp
@@ -9,6 +9,12 @@
 
 namespace DeviceRestart {
 
+// How long to let a disable settle before believing it was refused. Only ever
+// spent on the path that is about to conclude "nothing went down", so a device
+// that disables promptly pays none of it.
+static constexpr int   DISABLE_SETTLE_POLLS   = 10;
+static constexpr DWORD DISABLE_SETTLE_STEP_MS = 50;
+
 static bool SetDeviceState(HDEVINFO devs, SP_DEVINFO_DATA& devInfo,
                            DWORD stateChange, DWORD scope) {
     SP_PROPCHANGE_PARAMS pc{};
@@ -57,6 +63,16 @@ const char* VetoTypeName(PNP_VETO_TYPE type) {
 
 enum class RemoveOutcome { Error, Vetoed, Removed, RemovedButMissing };
 
+// A node that cannot be located is not "enabled" — it is absent, and callers
+// asking this question are checking whether a repair took.
+static bool IsDevNodeDisabledById(const std::wstring& instanceId, ULONG locateFlags) {
+    DEVINST devInst = 0;
+    if (CM_Locate_DevNodeW(&devInst, const_cast<DEVINSTID_W>(instanceId.c_str()),
+                           locateFlags) != CR_SUCCESS)
+        return true;
+    return IsDevNodeDisabled(devInst);
+}
+
 // Ask PnP to take the node out of the device tree.
 //
 // This is the only documented way to learn *why* a device will not go down: a
@@ -69,7 +85,7 @@ enum class RemoveOutcome { Error, Vetoed, Removed, RemovedButMissing };
 // hazard to work around: this only ever runs after a disable was already
 // refused, and a granted removal breaks every open handle, which is exactly
 // what the failed disable was supposed to do.
-static RemoveOutcome QueryRemoveAndRestore(DEVINST devInst, CycleResult& out) {
+static RemoveOutcome QueryRemoveAndRestore(DEVINST devInst, CycleResult* out) {
     // Both of these have to be captured up front: once the node is gone, the
     // DEVINST is stale and there is nothing left to ask.
     wchar_t instanceId[MAX_DEVICE_ID_LEN] = {};
@@ -85,8 +101,10 @@ static RemoveOutcome QueryRemoveAndRestore(DEVINST devInst, CycleResult& out) {
         devInst, &vetoType, vetoName, ARRAYSIZE(vetoName), CM_REMOVE_UI_NOT_OK);
 
     if (cr == CR_REMOVE_VETOED) {
-        out.vetoType = vetoType;
-        out.vetoName = vetoName;
+        if (out) {
+            out->vetoType = vetoType;
+            out->vetoName = vetoName;
+        }
         return RemoveOutcome::Vetoed;
     }
     if (cr != CR_SUCCESS)
@@ -106,6 +124,27 @@ static RemoveOutcome QueryRemoveAndRestore(DEVINST devInst, CycleResult& out) {
             return RemoveOutcome::Removed;
     }
     return RemoveOutcome::RemovedButMissing;
+}
+
+// Take the node out of the device tree and let PnP build it again from scratch.
+// The escape hatch for a devnode that will not enable in place: a node can sit
+// at problem 22 with ConfigFlags clear, and for those DICS_ENABLE reports
+// success and changes nothing however often it is asked, while a rebuild works.
+//
+// Returns true only when the node came back *and* came back enabled. Those are
+// not the same thing: a persistent ConfigFlags disable is read again by the
+// rebuilt node and disables it just as before, so a successful removal is no
+// evidence on its own that anything was fixed — and treating it as such would
+// throw away the pending record that is the only remaining way back.
+static bool RebuildDevNode(const std::wstring& instanceId) {
+    DEVINST devInst = 0;
+    if (CM_Locate_DevNodeW(&devInst, const_cast<DEVINSTID_W>(instanceId.c_str()),
+                           CM_LOCATE_DEVNODE_PHANTOM) != CR_SUCCESS)
+        return false;
+    if (QueryRemoveAndRestore(devInst, nullptr) != RemoveOutcome::Removed)
+        return false;
+    // Re-resolve: what came back is a different devnode instance.
+    return !IsDevNodeDisabledById(instanceId, CM_LOCATE_DEVNODE_NORMAL);
 }
 
 // Take the devnode down and bring it back, invalidating every open handle to
@@ -163,7 +202,19 @@ static void CycleDevNode(HDEVINFO devs, SP_DEVINFO_DATA& devInfo, CycleResult& o
 
     // Did it actually go down? This, not the return code above, decides
     // whether a real cycle happened.
-    const bool wentDown = IsDevNodeDisabled(devInfo.DevInst);
+    //
+    // Polled rather than read once. The devnode's status does not always
+    // reflect the disable by the time the call returns, and reading it too
+    // early is not a harmless misreading: "nothing went down" skips the
+    // re-enable below entirely and clears the pending record, so a disable that
+    // lands a moment later is left in place with nothing tracking it and a
+    // cycle verdict claiming the opposite. Reported from the field as
+    // collections sitting at problem 22 under a FELL BACK TO RESTART verdict.
+    bool wentDown = false;
+    for (int i = 0; i < DISABLE_SETTLE_POLLS && !wentDown; ++i) {
+        if (i) Sleep(DISABLE_SETTLE_STEP_MS);
+        wentDown = IsDevNodeDisabled(devInfo.DevInst);
+    }
 
     if (wentDown)
         Sleep(1000);  // let the removal propagate before bringing it back
@@ -180,11 +231,25 @@ static void CycleDevNode(HDEVINFO devs, SP_DEVINFO_DATA& devInfo, CycleResult& o
     }
 
     if (!enabled) {
+        // Enabling refused to take. Retrying it again achieves nothing — field
+        // reports have DICS_ENABLE returning success while the node stays at
+        // problem 22 however often it is asked — so take the node out of the
+        // tree and let it be built fresh instead. A disabled devnode has no
+        // open handles by definition, which is what makes a query-remove
+        // viable here when it would be vetoed on a live one.
+        const DWORD enableError = GetLastError();
+        if (RebuildDevNode(instanceId)) {
+            DisarmPendingDisable();
+            out.kind  = CycleKind::Removed;
+            out.error = ERROR_SUCCESS;
+            return;
+        }
+
         // The controller is stranded disabled — the caller must surface this,
         // it is not a quiet failure. The pending record deliberately stays
         // armed: this is exactly the state the next run has to clean up.
         out.kind  = CycleKind::Failed;
-        out.error = GetLastError();
+        out.error = enableError;
         return;
     }
 
@@ -200,7 +265,7 @@ static void CycleDevNode(HDEVINFO devs, SP_DEVINFO_DATA& devInfo, CycleResult& o
     // the removal route if PnP will grant it — a plain restart here is known
     // to change nothing at all.
     out.error = ERROR_NOT_SUPPORTED;
-    switch (QueryRemoveAndRestore(devInfo.DevInst, out)) {
+    switch (QueryRemoveAndRestore(devInfo.DevInst, &out)) {
         case RemoveOutcome::Removed:
             out.kind  = CycleKind::Removed;
             out.error = ERROR_SUCCESS;
@@ -282,6 +347,7 @@ bool WriteCycleStatus(const CycleResult& result) {
     fwprintf(f, L"kind=%d\n",    static_cast<int>(result.kind));
     fwprintf(f, L"error=%lu\n",  result.error);
     fwprintf(f, L"veto=%d\n",    static_cast<int>(result.vetoType));
+    fwprintf(f, L"self=%d\n",    result.selfHeld ? 1 : 0);
     fwprintf(f, L"ticks=%llu\n", result.ticks);
     fwprintf(f, L"name=%s\n",       result.vetoName.c_str());
     fwprintf(f, L"holders=%s\n",    result.holders.c_str());
@@ -314,6 +380,8 @@ bool ReadCycleStatus(CycleResult& result) {
             result.error = ul;
         else if (swscanf_s(line, L"veto=%d", &value) == 1)
             result.vetoType = static_cast<PNP_VETO_TYPE>(value);
+        else if (swscanf_s(line, L"self=%d", &value) == 1)
+            result.selfHeld = value != 0;
         else if (swscanf_s(line, L"ticks=%llu", &ull) == 1)
             result.ticks = ull;
         else if (wcsncmp(line, L"name=", 5) == 0)
@@ -424,6 +492,14 @@ static bool EnableByInstanceId(const std::wstring& id, bool& wasDisabled) {
         }
     }
     SetupDiDestroyDeviceInfoList(devs);
+
+    // Enabling in place does not always work. A devnode can sit at problem 22
+    // with ConfigFlags clear — a disable that was never written to the registry
+    // — and for those, DICS_ENABLE reports success and changes nothing, no
+    // matter how many times it is asked. Rebuilding the node does work, and
+    // costs nothing extra when the enable above already succeeded.
+    if (!enabled)
+        enabled = RebuildDevNode(id);
     return enabled;
 }
 

--- a/src/app/DeviceRestart.h
+++ b/src/app/DeviceRestart.h
@@ -39,6 +39,12 @@ struct CycleResult {
     std::wstring  holdersAll;
     std::wstring  scanInfo;
     ULONGLONG     ticks    = 0;  // GetTickCount64() when the cycle finished
+    // Every handle found on the device belonged to this app. PnP refused the
+    // teardown because of something we are holding ourselves, so cycling again
+    // cannot help: the answer is to let go, not to restart the devnode. Only
+    // set when the scan ran to completion — a partial scan cannot prove that
+    // nobody else has it open.
+    bool          selfHeld = false;
 
     // Nothing that could invalidate another process's handle took place, so
     // repeating the cycle will achieve exactly as much as the last one did.

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -319,8 +319,15 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             // A controller arriving (plugged in, or re-arriving after a device
             // cycle) should be acquired straight away whenever control is
             // wanted — this is what wins the reopen race against Steam.
-            if (wp == DBT_DEVICEARRIVAL && m_wantControl)
+            if (wp == DBT_DEVICEARRIVAL && m_wantControl) {
+                // Our controller specifically, not merely something HID-shaped:
+                // the notification filter covers the whole HID class, so a mouse
+                // being plugged in mid-cycle would otherwise clear the guard and
+                // let us reopen the device we are busy cycling.
+                if (m_controller->IsConnected())
+                    m_cycleInFlight = false;
                 TryAcquireController();
+            }
         }
         return TRUE;
 
@@ -380,6 +387,7 @@ void TrayApp::ReleaseControl() {
     m_wantControl    = false;
     m_acquireRetries = 0;
     m_lastCycleTick  = 0;
+    m_cycleInFlight  = false;  // cleared with the tick it is measured against
     const bool hadControl = m_controller->IsGameModeActive();
     // Good citizen: restore lizard mode and close our HID handles so
     // Steam can claim the controller without contention.
@@ -397,6 +405,34 @@ void TrayApp::ReleaseControl() {
 }
 
 void TrayApp::TryAcquireController(uint32_t stateWaitMs) {
+    // Do not open the device while a cycle we asked for is still running. The
+    // claim below opens handles, the cycle needs every handle gone to take the
+    // devnode down, and PnP does not care that the handle blocking it is ours —
+    // it vetoes the cycle just the same. Reported from the field as the app
+    // cycling the puck against a handle held by SteamlessController.exe itself,
+    // which left the vendor collections disabled.
+    //
+    // The arrival that ends a cycle clears this, so the reopen race against
+    // Steam is not slowed down; the tick is only a backstop for a cycle that
+    // never produces one.
+    if (m_cycleInFlight) {
+        if (GetTickCount64() - m_lastCycleTick < CYCLE_MIN_GAP_MS) {
+            // Once per cycle: a receiver publishes an interface per slot and
+            // every arrival re-enters here, so saying it each time would bury
+            // the log in repeats of a single fact.
+            if (!m_inFlightLogged) {
+                m_inFlightLogged = true;
+                EventLog::Write("ACQUIRE: cycle still in flight — not opening the device "
+                                "(our own handle would veto it)");
+            }
+            SetTimer(m_hwnd, IDT_ACQUIRE, ACQUIRE_RETRY_MS, nullptr);
+            return;
+        }
+        EventLog::Write("ACQUIRE: cycle produced no arrival within %llu ms — claiming anyway",
+                        CYCLE_MIN_GAP_MS);
+        m_cycleInFlight = false;
+    }
+
     m_controller->OnDeviceChange();
     auto outcome = m_controller->EnableGameMode(stateWaitMs);
 
@@ -439,6 +475,18 @@ void TrayApp::TryAcquireController(uint32_t stateWaitMs) {
     // at :56.367. Wait for the one already running to finish instead.
     const ULONGLONG nowTick = GetTickCount64();
     if (m_lastCycleTick != 0 && nowTick - m_lastCycleTick < CYCLE_MIN_GAP_MS) {
+        SetTimer(m_hwnd, IDT_ACQUIRE, ACQUIRE_RETRY_MS, nullptr);
+        return;
+    }
+
+    // The last cycle was blocked by a handle of our own. Another cycle would be
+    // blocked by the same thing, and each attempt risks leaving the devnode
+    // switched off, so let go instead of restarting hardware to escape
+    // ourselves. Releasing costs nothing if it turns out we held nothing.
+    if (m_acquireRetries > 0 && RefreshCycleStatus() && m_lastCycleStatus.selfHeld) {
+        EventLog::Write("ACQUIRE: the last cycle was vetoed by this app's own handle — "
+                        "releasing it instead of cycling again");
+        m_controller->ReleaseDevices();
         SetTimer(m_hwnd, IDT_ACQUIRE, ACQUIRE_RETRY_MS, nullptr);
         return;
     }
@@ -701,6 +749,14 @@ void TrayApp::EnableDisabledControllerDevice() {
 }
 
 bool TrayApp::RestartControllerDevices() {
+    // Every cycle starts here, so the "do not reopen while this runs" flag is
+    // raised here rather than at each call site — the recovery cycle can be
+    // vetoed by our own handle exactly as readily as the acquire one, and the
+    // tick it is measured against has to move with it.
+    m_cycleInFlight  = true;
+    m_inFlightLogged = false;
+    m_lastCycleTick  = GetTickCount64();
+
     // On the rare elevated run, cycle directly. This works on every transport
     // including Bluetooth: the devnode being restarted is the HID child, not
     // the pairing (which lives up at the BTHLEDEVICE layer), and it
@@ -722,6 +778,9 @@ bool TrayApp::RestartControllerDevices() {
         // not care which path performed the cycle.
         summary.ticks = GetTickCount64();
         DeviceRestart::WriteCycleStatus(summary);
+        // Synchronous: the cycle has already finished and the device is back,
+        // so there is nothing left to hold the claim off for.
+        m_cycleInFlight = false;
         return anyRestarted;
     }
 
@@ -730,12 +789,16 @@ bool TrayApp::RestartControllerDevices() {
     std::wstring run = L"schtasks.exe /Run /TN \"";
     run += CYCLE_TASK_NAME;
     run += L"\"";
-    if (RunToolHidden(run)) return true;
+    if (RunToolHidden(run)) return true;  // asynchronous — flag stays raised
 
     // Task missing (copied exes without installing?) — register it with a
     // one-time UAC prompt, then retry.
-    if (!EnsureCycleTaskRegistered()) return false;
-    return RunToolHidden(std::move(run));
+    if (EnsureCycleTaskRegistered() && RunToolHidden(std::move(run)))
+        return true;
+
+    // No cycle was started, so nothing is running that our handle could veto.
+    m_cycleInFlight = false;
+    return false;
 }
 
 void TrayApp::ShowElevationBalloon() {

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -106,6 +106,12 @@ private:
     // the app having been blocked.
     ULONGLONG                          m_lastHeartbeatUnbiased = 0;
     ULONGLONG                          m_startTick = 0;
+    // A cycle we fired is still running. While set, the device is deliberately
+    // left unopened: our own handle vetoes the cycle just as readily as anyone
+    // else's. Cleared by the arrival that ends the cycle, or by the tick
+    // backstop when no arrival comes.
+    bool                               m_cycleInFlight = false;
+    bool                               m_inFlightLogged = false;  // one line per cycle
     // Devnode found disabled when the menu was last built, so the command
     // handler and the menu agree on what "re-enable" refers to.
     std::wstring                       m_disabledDeviceNode;

--- a/src/helper/DeviceCycleHelper.cpp
+++ b/src/helper/DeviceCycleHelper.cpp
@@ -157,6 +157,33 @@ static int CycleDevices() {
             r.holders    = HandleFinder::DescribeHolders(culprits);
             r.holdersAll = HandleFinder::DescribeHolders(scan.holders);
 
+            // Nothing on the device but our own handles. Cycling is the wrong
+            // tool for that: it tears a working devnode out of the tree to
+            // break a handle the app could simply have closed, and the veto
+            // that results is how a user's collections ended up stuck at
+            // problem 22 — every boot, because the acquire runs every boot.
+            // Note steam.exe is deliberately not in this list: it holds the
+            // device by design and yields on query-remove, so its presence
+            // means this is an ordinary contended cycle, not a self-inflicted
+            // one.
+            static const wchar_t* kOurOwn[] = {
+                L"SteamlessController.exe", L"SteamlessDeviceCycle.exe",
+            };
+            bool anyForeign = false;
+            for (const auto& h : scan.holders) {
+                bool ours = false;
+                for (const wchar_t* name : kOurOwn)
+                    if (_wcsicmp(h.image.c_str(), name) == 0) { ours = true; break; }
+                if (!ours) { anyForeign = true; break; }
+            }
+            // An incomplete scan cannot prove nobody else has it open, and
+            // acting on "only us" when the scan never finished would stop a
+            // cycle that was genuinely needed.
+            r.selfHeld = scan.completed && !scan.holders.empty() && !anyForeign;
+            if (r.selfHeld)
+                CycleLog("SELF-HELD: every handle on the device is this app's own — "
+                         "cycling cannot break a handle the app is responsible for");
+
             // Kept as a ready-made line so the tray app can put it straight
             // into the event log the user can actually reach and send.
             wchar_t info[512];


### PR DESCRIPTION
Fixes the device-disabling half of #65. The ViGEm half is split out as #66.

Reported against 1.13: the puck's vendor collections sat at problem 22 after the app cycled them, and did so again within seconds of every boot, because the acquire runs at every startup. The reporter's log names the blocker outright:

```
HOLDERS: all=[SteamlessController.exe (7696)] reportable=[none]
FELL BACK TO RESTART (transport=dongle err=50 veto=open handle 'HID\VID_28DE&PID_1304&MI_03&Col03\...')
```

## 1. The app vetoed its own cycles

The app already releases its handles before asking for a cycle — the bug is that it reopens too soon. `TryAcquireController` opens the device at the top, every arrival the cycle produces re-enters it, and the existing `CYCLE_MIN_GAP_MS` guard sits *below* that open, so it only ever stopped a second cycle stacking on the first, never the reopen. PnP does not care that the handle vetoing the teardown is ours. Each vetoed cycle is then a chance to leave the devnode switched off.

The claim is now held off while a cycle is in flight, raised where cycles are started so the recovery path is covered too, and cleared by the arrival that ends the cycle so the reopen race against Steam is not slowed. The helper additionally reports when every holder it found was one of our own processes, and the app releases rather than cycling again. `steam.exe` is deliberately excluded from that check: it holds the device by design and yields on query-remove, so its presence means an ordinary contended cycle, not a self-inflicted one.

## 2. The disable was judged too early

`IsDevNodeDisabled` was read once, immediately after the disable call. Read inside the settling gap it says "nothing went down", which skips the re-enable entirely and clears the pending record — leaving a devnode switched off with `ConfigFlags` already committed and nothing tracking it, under a cycle verdict claiming the opposite. That is how a `FELL BACK TO RESTART` verdict and a disabled collection come to coexist in the same log.

Measured on the four-slot receiver, the gap between the registry flag landing and the node admitting to problem 22 ran 96 ms to 330 ms across slots on an idle machine:

```
22:27:30.533  MI_03=0/1     flag written, node still reports healthy
22:27:30.863  MI_03=22/1    node catches up, 330 ms later
```

Wired was 46 ms, which is why this only shows up on a receiver. The window is sized for the bad case (~950 ms) rather than the measurement, and is only ever spent on the path about to conclude the disable failed.

## 3. Enabling in place does not always work

A node can sit at problem 22 with `ConfigFlags` clear, and for those `DICS_ENABLE` reports success and changes nothing however often it is asked, while rebuilding the node works. Remove and re-enumerate is now the fallback, in both the cycle and the recovery path.

Confirmed enabled after the rebuild, not merely removed — those are different things. A persistent `ConfigFlags` disable is read again by the rebuilt node and disables it just the same, so treating removal as proof would report success over a dead device *and* discard the pending record that is the only way back.

## Verification

Run on both transports; the receiver is the configuration from the report.

Wired (1302):

1. Normal cycle — `CYCLED`, no regression, settle poll costs nothing (disable seen 46 ms after arming).
2. Strand and recover — killed mid-cycle, relaunch recovered in 1.1 s.
3. In-flight suppression — forced re-entry by posting `WM_TIMER`/`IDT_ACQUIRE`, which is what the retry timer delivers. Ten re-entries suppressed, game mode 61 ms after the arrival cleared the flag.
4. Rebuild fallback — forced the in-place enable off against a node with `ConfigFlags=1`. Correctly reported `STILL DISABLED` rather than a false success, which is the failure mode guarded against above.

Receiver (1304, four slots):

1. Normal cycle — all four collections cycled and returned healthy.
2. Strand and recover — one slot left at problem 22, other three untouched, record correctly scoped to that slot and its parent; relaunch recovered it and reached game mode.
3. Blocked claim — one cycle attempt, immediately successful, no escalation, nothing left disabled.

The in-flight guard also fired unprompted during (2), which is the reported mechanism being intercepted in the configuration it was reported against:

```
22:27:29.429  RECOVER: a previous run was interrupted mid-cycle ...
22:27:29.504  ACQUIRE: cycle still in flight — not opening the device (our own handle would veto it)
22:27:31.942  GAMEMODE: enabled
```

## Not verified

- **The reporter's non-persistent state** (problem 22 with `ConfigFlags` clear). Every disable on this hardware takes the global route and sets the flag, on both transports, so "rebuild recovers a node `DICS_ENABLE` will not" rests on their measurement rather than one taken here.
- **`selfHeld` firing.** The field round-trips through the status file, but fix 1 prevents us holding a handle during a cycle, so the detection is unreachable on this machine by design.

Both are reachable on the reporter's setup, and they offered to test a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
