### PR TITLE
Stop a missing ViGEm bus from being treated as a contested controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,19 @@ if (MSVC)
     set_target_properties(BindingCodecProbe PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")
 endif()
 
+# Virtual gamepad bus probe — dumps every bus the ViGEm client can see, which
+# is the one question a "vigem_connect failed" report cannot answer on its own
+add_executable(ViGEmBusProbe
+    src/probe/ViGEmBusProbe.cpp
+    src/app/ViGEmBusInfo.cpp
+)
+target_include_directories(ViGEmBusProbe PRIVATE src)
+target_link_libraries(ViGEmBusProbe PRIVATE ViGEmClient)
+if (MSVC)
+    target_compile_options(ViGEmBusProbe PRIVATE /W4 /WX /utf-8 /wd4828)
+    set_target_properties(ViGEmBusProbe PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")
+endif()
+
 # Elevated on-demand helper — restarts the controller device node so the tray
 # app (which never runs elevated) can take the device from a running Steam.
 add_executable(SteamlessDeviceCycle WIN32
@@ -149,6 +162,7 @@ add_executable(SteamlessController WIN32
     src/app/HandleFinder.cpp
     src/app/RemapWindow.cpp
     src/app/SteamAppLocator.cpp
+    src/app/ViGEmBusInfo.cpp
     resources/app.rc
 )
 target_include_directories(SteamlessController PRIVATE

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -48,6 +48,9 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 Source: "build\release\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "build\release\Release\SteamlessDeviceCycle.exe"; DestDir: "{app}"; Flags: ignoreversion
+; Setup's driver check, and the thing to ask a user to run when a controller
+; never reaches a game. Installed rather than temporary for the second reason.
+Source: "build\release\Release\ViGEmBusProbe.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "resources\{#ViGEmSetup}"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Icons]
@@ -64,4 +67,74 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 
 [UninstallRun]
 Filename: "{app}\SteamlessDeviceCycle.exe"; Parameters: "--unregister"; RunOnceId: "RemoveCycleTask"; Flags: waituntilterminated runhidden
+
+[Code]
+// Did ViGEmBus actually install? Established the way the app establishes it at
+// runtime — by enumerating the ViGEm bus interface — because every cheaper
+// answer has been measured and found to lie:
+//
+//   * the bundle exits 0 when it finds a related product already registered
+//     and decides there is nothing for it to do
+//   * the registry records the product whether or not a driver ever landed
+//   * the driver's own version is no guide either: 1.22.0 ships a binary still
+//     stamped 1.21.442.0
+//
+// Reported in #68: with another program's rebranded ViGEm already present,
+// setup looked entirely successful and left the machine with no working bus.
+// The user found out when they clicked Enable Steamless Mode.
+function ViGEmBusPresent(): Boolean;
+var
+  ResultCode: Integer;
+begin
+  // Assume the best when the check itself cannot run. A missing or broken
+  // probe is our bug, and telling every user their driver failed on account of
+  // it would be worse than saying nothing at all.
+  Result := True;
+  if not Exec(ExpandConstant('{app}\ViGEmBusProbe.exe'), '', '',
+              SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    Log('ViGEmBus verification: probe could not be run');
+    Exit;
+  end;
+  Log('ViGEmBus verification: probe exit code ' + IntToStr(ResultCode));
+  Result := ResultCode = 0;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  WarningText: String;
+begin
+  // ssPostInstall runs after the [Run] entries above, so the driver installer
+  // has finished by the time this fires. Worth stating because it is
+  // load-bearing: were that ordering ever wrong, every healthy install would
+  // warn. That is a loud failure rather than a quiet one, which is why the
+  // check sits here rather than behind a wrapper built to guarantee ordering.
+  if CurStep <> ssPostInstall then
+    Exit;
+  if ViGEmBusPresent() then
+    Exit;
+
+  WarningText :=
+    'SteamlessController is installed, but the ViGEmBus driver is not.' + #13#10 + #13#10 +
+    'That driver is what presents your controller to games. Setup ran its ' +
+    'installer, but no virtual gamepad bus is present afterwards. Usually this ' +
+    'means another program has already registered a version of it — Oculus and ' +
+    'Virtual Desktop both ship their own copy — which stops the bundled ' +
+    'installer from doing anything.' + #13#10 + #13#10 +
+    'To finish:' + #13#10 + #13#10 +
+    '    1. Download ViGEmBus from' + #13#10 +
+    '        https://github.com/nefarius/ViGEmBus/releases/latest' + #13#10 +
+    '    2. Run it, choosing Repair if it offers that rather than a fresh install' + #13#10 +
+    '    3. Start SteamlessController — it picks the driver up on its own,' + #13#10 +
+    '        with no reinstall and no restart needed' + #13#10 + #13#10 +
+    'To check again later, run ViGEmBusProbe.exe from the installation folder.';
+
+  // An unattended install must not stop on a dialog nobody is there to close.
+  // The Inno log carries the same finding either way, and so will the app's
+  // event log the first time somebody enables Steamless Mode.
+  if WizardSilent() then
+    Log('ViGEmBus verification: no bus present after install (silent, not shown)')
+  else
+    MsgBox(WarningText, mbInformation, MB_OK);
+end;
 

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -1,6 +1,7 @@
 #include "ControllerManager.h"
 #include "EventLog.h"
 #include "InputInjection.h"
+#include "ViGEmBusInfo.h"
 #include "VirtualController.h"
 #include "TrackpadMouse.h"
 #include "KeyInput.h"
@@ -200,6 +201,22 @@ void ControllerManager::EmergencyRestoreAll() noexcept {
     }
 }
 
+// EventLog's %ls reaches fprintf, which converts wide characters through the C
+// locale and silently abandons the rest of the line at the first one it cannot
+// encode. Measured: a bus report ending in an em dash logged as its first
+// clause and nothing else. Device names on a localised Windows will do the
+// same, so hand the log UTF-8 bytes and let %s pass them through untouched.
+static std::string Utf8(const std::wstring& text) {
+    if (text.empty()) return {};
+    const int bytes = WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1,
+                                          nullptr, 0, nullptr, nullptr);
+    if (bytes <= 1) return {};
+    std::string out(static_cast<size_t>(bytes), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1, out.data(), bytes, nullptr, nullptr);
+    out.resize(static_cast<size_t>(bytes) - 1);  // drop the terminator
+    return out;
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -243,22 +260,40 @@ void ControllerManager::OnDeviceChange() {
 }
 
 ControllerManager::GameModeOutcome ControllerManager::EnableGameMode(uint32_t stateWaitMs) {
-    bool anyVigemMissing = false;
-    bool anyBlocked      = false;
-    bool anyEnabled      = false;
+    // Once the absence of a bus driver is established, re-establish it the
+    // cheap way. Finding out by attempting an enable costs the user's
+    // controller: each attempt claims the device exclusively and toggles
+    // lizard mode off and back on, and the retry that waits for a driver to
+    // be installed would otherwise do that every 30 seconds for as long as
+    // the machine goes without one. Enumerating touches no device at all.
+    if (m_lastPadDriverMissing && ViGEmBusInfo::Enumerate().empty()) {
+        NotifyStateChanged(true);
+        return GameModeOutcome::VirtualPadUnavailable;
+    }
+
+    bool anyPadUnavailable = false;
+    bool anyBlocked        = false;
+    bool anyEnabled        = false;
     for (auto& slot : m_slots) {
-        switch (EnableGameModeSlot(*slot, anyVigemMissing, stateWaitMs)) {
-        case GameModeOutcome::Enabled:            anyEnabled = true; break;
-        case GameModeOutcome::Blocked:            anyBlocked = true; break;
-        case GameModeOutcome::NoActiveController: break;
+        switch (EnableGameModeSlot(*slot, anyPadUnavailable, stateWaitMs)) {
+        case GameModeOutcome::Enabled:               anyEnabled = true; break;
+        case GameModeOutcome::Blocked:               anyBlocked = true; break;
+        case GameModeOutcome::VirtualPadUnavailable: break;  // tracked by the out-param
+        case GameModeOutcome::NoActiveController:    break;
         }
     }
-    NotifyStateChanged(anyVigemMissing);
+    NotifyStateChanged(anyPadUnavailable);
     if (anyEnabled) return GameModeOutcome::Enabled;
     // Only report Blocked when something actually stood in the way. Slots that
     // are merely silent mean no controller is switched on, which no amount of
     // device cycling will change.
-    return anyBlocked ? GameModeOutcome::Blocked : GameModeOutcome::NoActiveController;
+    //
+    // Blocked outranks a missing pad: contention is the one of the two a
+    // device cycle can still resolve, so if any slot is contested the caller
+    // should hear about that rather than settle into the slow ViGEm retry.
+    if (anyBlocked)        return GameModeOutcome::Blocked;
+    if (anyPadUnavailable) return GameModeOutcome::VirtualPadUnavailable;
+    return GameModeOutcome::NoActiveController;
 }
 
 void ControllerManager::DisableGameMode() {
@@ -467,7 +502,7 @@ void ControllerManager::OpenSlot(const std::wstring& path) {
 // ---------------------------------------------------------------------------
 
 ControllerManager::GameModeOutcome
-ControllerManager::EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
+ControllerManager::EnableGameModeSlot(Slot& slot, bool& padUnavailableOut,
                                       uint32_t stateWaitMs) {
     if (slot.gameModeActive) return GameModeOutcome::Enabled;
     // The puck publishes a controller interface per slot and current firmware
@@ -523,11 +558,30 @@ ControllerManager::EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
         EventLog::Write("GAMEMODE: ViGEm virtual controller failed (stage=%s, err=0x%08X, driverMissing=%d)",
                         slot.vc->FailStage(), slot.vc->LastError(),
                         slot.vc->IsDriverMissing() ? 1 : 0);
-        if (slot.vc->IsDriverMissing()) vigemMissingOut = true;
+        // The line above says a call failed; this one says what the machine
+        // actually looks like. A second bus is the most likely cause of an
+        // otherwise inexplicable connect failure and the hardest thing to
+        // guess at from the outside, so it goes in the log every time.
+        if (!slot.vc->BusReport().empty()) {
+            EventLog::Write("GAMEMODE: %s", Utf8(slot.vc->BusReport()).c_str());
+            m_lastBusReport = slot.vc->BusReport();
+        }
+        m_lastPadDriverMissing = slot.vc->IsDriverMissing();
+        padUnavailableOut      = true;
         slot.vc.reset();
         slot.sc->EnableLizardMode();
-        return GameModeOutcome::Blocked;
+        // Hand the device back. Without a virtual pad this slot is going
+        // nowhere, and an exclusive handle held for nothing locks Steam out
+        // and makes the app itself the holder that vetoes its own device
+        // cycle — which is the veto the reporter's #65 logs recorded.
+        slot.sc->ReleaseToShared();
+        return GameModeOutcome::VirtualPadUnavailable;
     }
+
+    // A pad was created, so whatever was missing is not missing now — clear it
+    // or the cheap pre-flight above would keep short-circuiting a machine that
+    // has since had the driver installed.
+    m_lastPadDriverMissing = false;
 
     if (m_profile.platform == ControllerPlatform::PlayStation)
         slot.sc->SetImuEnabled(true);
@@ -962,6 +1016,6 @@ void ControllerManager::ReadLoop(Slot* slot) {
     }
 }
 
-void ControllerManager::NotifyStateChanged(bool vigemMissing) {
-    m_onStateChanged(!m_slots.empty(), IsGameModeActive(), vigemMissing);
+void ControllerManager::NotifyStateChanged(bool padUnavailable) {
+    m_onStateChanged(!m_slots.empty(), IsGameModeActive(), padUnavailable);
 }

--- a/src/app/ControllerManager.h
+++ b/src/app/ControllerManager.h
@@ -31,7 +31,13 @@ public:
     // a contested one. A puck publishes a slot interface whether or not a
     // controller is paired into it, and cycling the device because nothing is
     // switched on is pointless churn.
-    enum class GameModeOutcome { Enabled, NoActiveController, Blocked };
+    //
+    // VirtualPadUnavailable is emphatically not Blocked: nothing is wrong with
+    // the controller, so retrying fast or restarting its devnode accomplishes
+    // nothing. Reporting it as Blocked is what pointed the device-cycling
+    // machinery at a reporter's puck over a missing bus driver and left its
+    // HID collections disabled (#65).
+    enum class GameModeOutcome { Enabled, NoActiveController, Blocked, VirtualPadUnavailable };
 
     // stateWaitMs is how long each slot is given to prove it is live. Short
     // values are for polling a receiver whose controller is switched off —
@@ -65,6 +71,14 @@ public:
     bool IsGameModeActive()         const;
     const ControllerProfile& GetProfile() const { return m_profile; }
 
+    // Set when a virtual pad could not be created, so the tray can say which
+    // of the two very different problems it was: no bus driver at all (go
+    // install one) or a bus that is present and did not work (a rebranded fork
+    // is the usual reason, and telling the user to install ViGEmBus again
+    // would be wrong). Both are only meaningful after a failed enable.
+    bool                LastPadDriverMissing() const { return m_lastPadDriverMissing; }
+    const std::wstring& LastBusReport()        const { return m_lastBusReport; }
+
     // Called by RemapWindow when a row enters/exits listening state.
     // Callback fires on the read thread — use PostMessage to marshal to the UI thread.
     void StartButtonCapture(std::function<void(const BackButtonBinding&)> callback);
@@ -75,14 +89,14 @@ private:
 
     void SyncDevices();
     void OpenSlot(const std::wstring& path);
-    GameModeOutcome EnableGameModeSlot(Slot& slot, bool& vigemMissingOut,
+    GameModeOutcome EnableGameModeSlot(Slot& slot, bool& padUnavailableOut,
                                        uint32_t stateWaitMs);
     void DisableGameModeSlot(Slot& slot);
     void ReleaseHeldPaddleInputs(Slot& slot);
     void StartReadLoop(Slot& slot);
     void StopReadLoop(Slot& slot);
     void ReadLoop(Slot* slot);
-    void NotifyStateChanged(bool vigemMissing = false);
+    void NotifyStateChanged(bool padUnavailable = false);
 
     // Pushes the current profile's pad settings into one slot's trackpads and
     // its virtual controller. Shared by SetProfile and slot creation.
@@ -92,6 +106,8 @@ private:
     AlertFn                            m_alertFn;
     std::vector<std::unique_ptr<Slot>> m_slots;
     bool                               m_steamPresent         = false;
+    bool                               m_lastPadDriverMissing = false;
+    std::wstring                       m_lastBusReport;
     ControllerProfile                  m_profile;
 
     std::atomic<bool>                            m_capturing{false};

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -499,6 +499,9 @@ void TrayApp::ReleaseControl() {
     m_acquireRetries = 0;
     m_lastCycleTick  = 0;
     m_cycleInFlight  = false;  // cleared with the tick it is measured against
+    // One driver notice per attempt, and letting go ends the attempt. Turning
+    // Steamless Mode back on is a fresh ask and deserves a fresh answer.
+    m_vigemBalloonShown = false;
     // Whatever game profile was live belongs to a controller we no longer
     // have. Dropping it now means re-acquiring starts from the default and
     // re-resolves, rather than resuming a profile for a game long since quit.
@@ -554,7 +557,14 @@ void TrayApp::TryAcquireController(uint32_t stateWaitMs) {
     // A short burst of rapid retries: right after a device cycle we race
     // Steam's re-enumeration for the exclusive open, and starting the claim
     // the instant the device arrives is what wins that race.
-    for (int i = 0; i < 10 && !m_controller->IsGameModeActive(); ++i) {
+    //
+    // A missing virtual pad is not a race with anybody, so the burst is called
+    // off the moment that is the answer. Left running it re-attempted eleven
+    // times in half a second and re-armed the driver notification on each
+    // pass — the toast storm reported in #68.
+    for (int i = 0; i < 10
+                 && outcome != ControllerManager::GameModeOutcome::VirtualPadUnavailable
+                 && !m_controller->IsGameModeActive(); ++i) {
         Sleep(50);
         m_controller->OnDeviceChange();
         outcome = m_controller->EnableGameMode(stateWaitMs);
@@ -571,6 +581,22 @@ void TrayApp::TryAcquireController(uint32_t stateWaitMs) {
         return;
     }
     if (!m_controller->IsConnected()) return;  // nothing plugged in — arrival will retrigger
+
+    // The controller is fine; we just have nowhere to send its input. None of
+    // the machinery below applies — the retry counter, the cycling, and the
+    // holder scan all exist to get a HID handle away from another process,
+    // and no amount of restarting the puck installs a bus driver. Cycling
+    // here is exactly what disabled a reporter's HID collections in #65.
+    //
+    // So sit on a slow timer instead. The user is being told what to install,
+    // and this is what notices once they have.
+    if (outcome == ControllerManager::GameModeOutcome::VirtualPadUnavailable) {
+        // A verdict left pending by an earlier contested attempt would report
+        // this as Steam holding the controller, which it plainly is not.
+        KillTimer(m_hwnd, IDT_ACQUIRE_VERDICT);
+        SetTimer(m_hwnd, IDT_ACQUIRE, VIGEM_RETRY_MS, nullptr);
+        return;
+    }
 
     // No slot is emitting state: the controller is off, asleep, or the
     // receiver has no controller paired into it. Cycling cannot conjure one
@@ -990,16 +1016,21 @@ void TrayApp::RemoveTrayIcon() {
     Shell_NotifyIconW(NIM_DELETE, &nid);
 }
 
-void TrayApp::UpdateTrayIcon(bool connected, bool gameModeActive, bool vigemMissing) {
-    if (vigemMissing) ShowViGEmBalloon();
-    else              m_vigemBalloonShown = false;
+void TrayApp::UpdateTrayIcon(bool connected, bool gameModeActive, bool padUnavailable) {
+    if (padUnavailable) ShowViGEmBalloon();
+    // Cleared only by a pad that actually came up, not by any notification
+    // that happens to carry false. The acquire path notifies repeatedly within
+    // a single attempt, so clearing on false re-armed the balloon between
+    // consecutive failures and turned one attempt into a burst of toasts.
+    // ReleaseControl clears it too, so a deliberate re-enable says it again.
+    else if (gameModeActive) m_vigemBalloonShown = false;
 
     // Fall through rather than returning early — the icon and tooltip still need
     // to track the controller while the driver is unavailable.
-    const wchar_t* tip = gameModeActive ? L"Steamless Controller — Steamless Mode ON"
-                       : vigemMissing   ? L"Steamless Controller — ViGEmBus driver unavailable"
-                       : connected      ? L"Steamless Controller — Connected (Steamless Mode OFF)"
-                                        : L"Steamless Controller — No controller found";
+    const wchar_t* tip = gameModeActive  ? L"Steamless Controller — Steamless Mode ON"
+                       : padUnavailable  ? L"Steamless Controller — no virtual gamepad bus"
+                       : connected       ? L"Steamless Controller — Connected (Steamless Mode OFF)"
+                                         : L"Steamless Controller — No controller found";
 
     NOTIFYICONDATAW nid{};
     nid.cbSize = sizeof(nid);
@@ -1039,8 +1070,22 @@ void TrayApp::OpenEventLog() {
 // gets a wall of identical balloons. UpdateTrayIcon clears the latch once the
 // driver is reachable again, so a genuine mid-session disappearance still warns.
 void TrayApp::ShowViGEmBalloon() {
+    if (!m_notificationsEnabled) return;
     if (m_vigemBalloonShown) return;
     m_vigemBalloonShown = true;
+
+    // Two different problems wear the same failure internally, and the advice
+    // for one is wrong for the other. Telling somebody who already has a bus
+    // to go install ViGEmBus is what #65 spent three weeks on, so say which
+    // case this is — the manager established it by enumerating, not by
+    // guessing from an error code.
+    //
+    // Missing is by far the likelier of the two: the one confirmed way to get
+    // here is an installer that skipped ViGEmBus (#68). The other branch names
+    // no culprit on purpose — a bus that is present and unusable has several
+    // possible causes and we have never seen one in the field.
+    const bool missing = m_controller->LastPadDriverMissing();
+    m_balloonAction = missing ? BalloonAction::ViGEmDownload : BalloonAction::None;
 
     NOTIFYICONDATAW nid{};
     nid.cbSize           = sizeof(nid);
@@ -1048,10 +1093,14 @@ void TrayApp::ShowViGEmBalloon() {
     nid.uID              = TRAY_UID;
     nid.uFlags           = NIF_INFO;
     nid.dwInfoFlags      = NIIF_WARNING;
-    wcscpy_s(nid.szInfoTitle, L"Driver required");
+    wcscpy_s(nid.szInfoTitle, missing ? L"Driver required" : L"Virtual gamepad unavailable");
     wcscpy_s(nid.szInfo,
-             L"ViGEmBus is unavailable — not installed, or disabled in Device "
-             L"Manager under System devices. Click here to download it.");
+             missing
+                 ? L"ViGEmBus is unavailable — not installed, or disabled in Device "
+                   L"Manager under System devices. Click here to download it."
+                 : L"A virtual gamepad bus is present but would not accept a "
+                   L"controller. It may be disabled, or a version this app cannot "
+                   L"talk to. The event log has the details.");
     Shell_NotifyIconW(NIM_MODIFY, &nid);
 }
 
@@ -1367,6 +1416,17 @@ void TrayApp::SaveSettings() {
 }
 
 void TrayApp::ShowContextMenu() {
+    // Re-enumerate before reading state off the manager. Releasing the
+    // controller clears its slot list and only a device event refills it, so
+    // after a manual disable the menu grayed out its own toggle as "(no
+    // controller detected)" and stayed that way — the controller was sitting
+    // right there, and only restarting the app brought the toggle back (#68).
+    //
+    // Not while a cycle we asked for is running, though: this opens handles,
+    // and an open handle is what vetoes a cycle, ours included.
+    if (!m_cycleInFlight)
+        m_controller->OnDeviceChange();
+
     bool connected    = m_controller->IsConnected();
     bool gameModeOn   = m_controller->IsGameModeActive();
     bool startupOn    = m_startupEnabled;

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -34,7 +34,7 @@ private:
 
     void AddTrayIcon();
     void RemoveTrayIcon();
-    void UpdateTrayIcon(bool connected, bool gameModeActive, bool vigemMissing = false);
+    void UpdateTrayIcon(bool connected, bool gameModeActive, bool padUnavailable = false);
     void ShowViGEmBalloon();
 
     // What clicking the balloon should do. Balloons are transient and the click
@@ -122,6 +122,11 @@ private:
     // Verdict of the most recent device cycle, read back from the helper.
     DeviceRestart::CycleResult         m_lastCycleStatus;
     bool                               m_elevationBalloonShown = false;
+    // Latched for the lifetime of one attempt, and deliberately not cleared by
+    // an ordinary state notification: the acquire path notifies several times
+    // per attempt, and clearing it there let a single attempt raise a balloon
+    // on every pass. Reported from the field as toasts Windows was still
+    // replaying minutes after the app had been closed (#68).
     bool                               m_vigemBalloonShown     = false;
     bool                               m_startupEnabled   = false;
     int                                m_startupMechanism = 0;  // 0 none, 1 Run key, 2 elevated task
@@ -218,6 +223,12 @@ private:
     static constexpr UINT ACQUIRE_RETRY_MS   = 4000;
     // Grace after the final cycle before reporting failure to the user.
     static constexpr UINT ACQUIRE_VERDICT_MS = 3000;
+    // Retry spacing when the controller is fine but no virtual pad can be
+    // created. Nothing here is a race, so the fast cadence above buys nothing:
+    // what it is waiting for is a human installing a driver. Slow enough that
+    // waiting through the whole thing costs a handful of log lines, quick
+    // enough that the app picks a new driver up on its own.
+    static constexpr UINT VIGEM_RETRY_MS = 30000;
     // Minimum spacing between device cycles. A cycle is asynchronous, so
     // without this the arrivals it generates re-enter the acquire path and
     // fire another one on top of it.

--- a/src/app/ViGEmBusInfo.cpp
+++ b/src/app/ViGEmBusInfo.cpp
@@ -1,0 +1,91 @@
+#include "ViGEmBusInfo.h"
+
+#include <windows.h>
+#include <setupapi.h>
+
+// GUID_DEVINTERFACE_BUSENUM_VIGEM. Taken from the vendored client rather than
+// copied, so updating third_party cannot leave a stale value behind here — the
+// header itself tells forks to change the GUID, which is the whole reason this
+// file exists. Declared here and defined in ViGEmClient.obj, which includes
+// <initguid.h> ahead of the same header.
+#include <ViGEm/km/BusShared.h>
+
+namespace {
+
+// SPDRP_FRIENDLYNAME is what Device Manager shows and what a fork rebrands:
+// "Nefarius Virtual Gamepad Emulation Bus" against "Oculus Virtual Gamepad
+// Emulation Bus". Not every devnode sets one, so fall back to its description.
+std::wstring ReadName(HDEVINFO set, SP_DEVINFO_DATA& info) {
+    for (const DWORD prop : {SPDRP_FRIENDLYNAME, SPDRP_DEVICEDESC}) {
+        DWORD bytes = 0;
+        SetupDiGetDeviceRegistryPropertyW(set, &info, prop, nullptr, nullptr, 0, &bytes);
+        if (bytes == 0) continue;
+
+        std::wstring value(bytes / sizeof(wchar_t) + 1, L'\0');
+        if (!SetupDiGetDeviceRegistryPropertyW(set, &info, prop, nullptr,
+                                               reinterpret_cast<PBYTE>(value.data()),
+                                               bytes, nullptr))
+            continue;
+
+        value.resize(wcslen(value.c_str()));
+        if (!value.empty()) return value;
+    }
+    return {};
+}
+
+}  // namespace
+
+std::vector<ViGEmBusInfo::Bus> ViGEmBusInfo::Enumerate() {
+    std::vector<Bus> buses;
+
+    const HDEVINFO set = SetupDiGetClassDevsW(&GUID_DEVINTERFACE_BUSENUM_VIGEM,
+                                              nullptr, nullptr,
+                                              DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+    if (set == INVALID_HANDLE_VALUE) return buses;
+
+    SP_DEVICE_INTERFACE_DATA iface{};
+    iface.cbSize = sizeof(iface);
+    for (DWORD i = 0;
+         SetupDiEnumDeviceInterfaces(set, nullptr, &GUID_DEVINTERFACE_BUSENUM_VIGEM,
+                                     i, &iface);
+         ++i) {
+        DWORD bytes = 0;
+        SetupDiGetDeviceInterfaceDetailW(set, &iface, nullptr, 0, &bytes, nullptr);
+        if (bytes == 0) continue;
+
+        std::vector<BYTE> buffer(bytes);
+        auto* detail = reinterpret_cast<PSP_DEVICE_INTERFACE_DETAIL_DATA_W>(buffer.data());
+        detail->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W);
+
+        SP_DEVINFO_DATA info{};
+        info.cbSize = sizeof(info);
+        if (!SetupDiGetDeviceInterfaceDetailW(set, &iface, detail, bytes, nullptr, &info))
+            continue;
+
+        buses.push_back({detail->DevicePath, ReadName(set, info)});
+    }
+
+    SetupDiDestroyDeviceInfoList(set);
+    return buses;
+}
+
+std::wstring ViGEmBusInfo::Describe(const std::vector<Bus>& buses) {
+    if (buses.empty())
+        return L"no virtual gamepad bus is present — ViGEmBus is not installed, "
+               L"or its device is disabled in Device Manager under System devices";
+
+    // The count leads, because more than one is the answer to the question a
+    // maintainer reading this line is actually asking.
+    std::wstring text = std::to_wstring(buses.size());
+    text += (buses.size() == 1)
+          ? L" virtual gamepad bus present: "
+          : L" virtual gamepad buses present — the client connects to whichever "
+            L"answers first, which may not be the one this app needs: ";
+
+    for (size_t i = 0; i < buses.size(); ++i) {
+        if (i != 0) text += L", ";
+        text += buses[i].friendlyName.empty() ? buses[i].devicePath
+                                              : buses[i].friendlyName;
+    }
+    return text;
+}

--- a/src/app/ViGEmBusInfo.h
+++ b/src/app/ViGEmBusInfo.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <string>
+#include <vector>
+
+// What virtual gamepad buses are actually present.
+//
+// The ViGEm client finds its bus by enumerating one interface GUID and taking
+// the first device that answers, with no notion of which product published it.
+// Its error codes are no better: VIGEM_ERROR_BUS_NOT_FOUND covers both "no
+// driver installed" and "a bus is there and did not answer". The app used to
+// infer the first from an error that means either, which sent a reporter
+// hunting for a driver they did not have and could not tell they lacked (#65).
+//
+// So ask the system instead of guessing from an error code.
+//
+// Worth knowing what this does *not* see. Rebranded ViGEm forks ship with
+// several products (Oculus and Virtual Desktop both ship one), and the
+// upstream header instructs forks to change this GUID — measured in #68, on a
+// machine carrying both of those forks, neither published it and only the
+// Nefarius bus appeared. So an empty result really does mean no usable bus,
+// which is what makes it safe to drive "the driver is missing" off of.
+namespace ViGEmBusInfo {
+
+// Only buses that are actually usable appear here. Measured on a disabled
+// ViGEmBus: the devnode stays present and reports a problem, but its interface
+// is withdrawn entirely, so a disabled bus reads the same as an absent one.
+// That is why "disabled in Device Manager" belongs in the empty-list wording
+// rather than in a separate state nothing ever reaches.
+struct Bus {
+    std::wstring devicePath;    // \\?\ROOT#SYSTEM#0001#{96e42b22-...}
+    std::wstring friendlyName;  // as Device Manager shows it; may be empty
+};
+
+// Every present device publishing the ViGEm bus interface. Empty is the one
+// case that genuinely means "go install the driver".
+std::vector<Bus> Enumerate();
+
+// One log line: how many buses answered, and what they call themselves.
+std::wstring Describe(const std::vector<Bus>& buses);
+
+}  // namespace ViGEmBusInfo

--- a/src/app/VirtualController.cpp
+++ b/src/app/VirtualController.cpp
@@ -1,4 +1,5 @@
 #include "VirtualController.h"
+#include "ViGEmBusInfo.h"
 #include "steam/SteamController.h"
 #include <ViGEm/Client.h>
 #include <algorithm>
@@ -162,8 +163,13 @@ VirtualController::VirtualController(ControllerPlatform platform, RumbleCallback
     if (!VIGEM_SUCCESS(err)) {
         m_failStage = "vigem_connect";
         m_lastError = static_cast<uint32_t>(err);
-        if (err == VIGEM_ERROR_BUS_NOT_FOUND || err == VIGEM_ERROR_BUS_ACCESS_FAILED)
-            m_driverMissing = true;
+        // The error code cannot tell these apart: the client returns
+        // BUS_NOT_FOUND both when no bus is installed and when one is present
+        // but did not answer, and it never says which product's bus it tried.
+        // Ask the system what is actually there and report only that.
+        const auto buses = ViGEmBusInfo::Enumerate();
+        m_busReport     = ViGEmBusInfo::Describe(buses);
+        m_driverMissing = buses.empty();
         vigem_free(static_cast<PVIGEM_CLIENT>(m_client));
         m_client = nullptr;
         return;

--- a/src/app/VirtualController.h
+++ b/src/app/VirtualController.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <atomic>
 #include <functional>
+#include <string>
 #include <thread>
 #include "BackButtonConfig.h"
 #include "ControllerPlatform.h"
@@ -18,6 +19,10 @@ public:
     VirtualController& operator=(const VirtualController&) = delete;
 
     bool IsValid()        const { return m_valid; }
+    // Established by asking the system what buses exist, not inferred from an
+    // error code — VIGEM_ERROR_BUS_NOT_FOUND is returned for causes other than
+    // an absent driver, and reporting those as "driver missing" is what sent
+    // the reporter in #65 looking for a driver they already had.
     bool IsDriverMissing() const { return m_driverMissing; }
 
     // Why construction failed. Only meaningful when !IsValid(); FailStage() names
@@ -25,6 +30,10 @@ public:
     // (0 when the failing call returns no code, e.g. the allocators).
     const char* FailStage() const { return m_failStage; }
     uint32_t    LastError() const { return m_lastError; }
+
+    // What buses were on the machine when construction failed, for the log and
+    // for choosing what to tell the user. Empty unless a connect failed.
+    const std::wstring& BusReport() const { return m_busReport; }
 
     void Update(const uint8_t* buf, size_t n, const ControllerProfile& profile);
     void OnRumble(uint8_t largeMotor, uint8_t smallMotor);
@@ -45,6 +54,7 @@ private:
     bool   m_driverMissing = false;
     const char* m_failStage = "none";
     uint32_t    m_lastError = 0;
+    std::wstring m_busReport;
 
     // DS4 touchpad tracking. Which pads feed it is read from the profile
     // handed to Update every frame, so none of that is duplicated here.

--- a/src/probe/ViGEmBusProbe.cpp
+++ b/src/probe/ViGEmBusProbe.cpp
@@ -4,6 +4,18 @@
 // all, or one that belongs to somebody else — the client takes the first
 // device that answers and never records which. That ambiguity is what made #65
 // unfalsifiable from the logs, so this is the thing to ask a reporter to run.
+//
+// Setup runs it too, which is why the exit code is part of the contract:
+//
+//   0  at least one usable bus is present
+//   1  none — the driver is absent, or its device is switched off
+//
+// Every cheaper answer to "did ViGEmBus install?" has been measured and found
+// to lie. The bundle returns 0 when it detects a related product and declines
+// to act; the registry records the product whether or not a driver landed; and
+// the driver's own version is no guide either, since 1.22.0 ships a binary
+// still stamped 1.21.442.0. Enumerating the interface is the only check that
+// answers the question the app actually asks at runtime.
 
 #include "app/ViGEmBusInfo.h"
 
@@ -25,5 +37,5 @@ int wmain() {
         wprintf(L"\nMore than one bus is present. The client connects to whichever\n"
                 L"answers first, so which one it gets is not up to this app.\n");
 
-    return 0;
+    return buses.empty() ? 1 : 0;
 }

--- a/src/probe/ViGEmBusProbe.cpp
+++ b/src/probe/ViGEmBusProbe.cpp
@@ -1,0 +1,29 @@
+// Dumps every device publishing the ViGEm bus interface.
+//
+// A "vigem_connect failed" report cannot say whether the machine had no bus at
+// all, or one that belongs to somebody else — the client takes the first
+// device that answers and never records which. That ambiguity is what made #65
+// unfalsifiable from the logs, so this is the thing to ask a reporter to run.
+
+#include "app/ViGEmBusInfo.h"
+
+#include <cstdio>
+
+int wmain() {
+    const auto buses = ViGEmBusInfo::Enumerate();
+
+    wprintf(L"%ls\n\n", ViGEmBusInfo::Describe(buses).c_str());
+
+    for (size_t i = 0; i < buses.size(); ++i) {
+        wprintf(L"[%zu] %ls\n", i + 1,
+                buses[i].friendlyName.empty() ? L"(no friendly name)"
+                                              : buses[i].friendlyName.c_str());
+        wprintf(L"    %ls\n", buses[i].devicePath.c_str());
+    }
+
+    if (buses.size() > 1)
+        wprintf(L"\nMore than one bus is present. The client connects to whichever\n"
+                L"answers first, so which one it gets is not up to this app.\n");
+
+    return 0;
+}


### PR DESCRIPTION
Addresses all four of the still-broken items in #68, and removes the mechanism behind #65.

## The chain

Everything in that report runs from one root: with another program's rebranded ViGEm already on the machine, setup's driver install silently does nothing and reports success. No bus driver, so `vigem_connect` fails, so the app retried hard and — on 1.13 — cycled the controller's devnodes trying to fix a problem the controller never had. That is what left the reporter's HID collections stuck at problem code 22.

The first two commits make that state survivable and diagnosable. The third keeps it from being reached.

## Commits

**Ask the system which virtual gamepad buses exist instead of guessing** — `driverMissing` was inferred from `VIGEM_ERROR_BUS_NOT_FOUND`, which is returned for several causes, so an accurate report was indistinguishable from a wrong one. Now established by enumerating the bus interface, with the inventory logged next to the failure. Ships `ViGEmBusProbe` for the same question.

**Stop treating a missing ViGEm bus as a contested controller** — a virtual pad that could not be created was reported as `Blocked`, the same answer given when another process holds the device, and the acquire path answers `Blocked` by restarting the devnode. Now its own outcome, returned ahead of all the contention machinery. Also: the failing slot releases its exclusive handle, the driver notice fires once instead of ~11 times per attempt, the retry backs off to 30s and no longer disturbs the controller, the tray menu re-enumerates before drawing, and the bus report reaches the log as UTF-8.

**Check that ViGEmBus actually installed instead of assuming it did** — setup now asks the same question the app asks at runtime. Every cheaper check was measured and found to lie: the bundle exits 0 when it declines to act, the registry records the product whether or not a driver landed, and 1.22.0 ships a driver still stamped 1.21.442.0.

## Verification

Run against a real controller with the bus disabled, and against setup with Inno 6.7.3.

| | |
|---|---|
| Zero device cycles on a ViGEm failure | measured — previous build spent three |
| One toast, not a burst | measured |
| Recovery without restart | measured — game mode up 30s after re-enabling the bus |
| Tray toggle stays live after a manual disable | measured twice, incl. the rescan visible in the log |
| `driverMissing` correct, full inventory logged | measured both directions |
| Installer: compiles, ordering, warning, silent suppression, fresh install | measured, all five |

Ordering proof for the installer check is a fresh-install run where the probe returned 0 for a driver that existed only because the bundle had just installed it.

## Not covered

The fork trigger itself — no machine here carries one, so "does the bundle really no-op against a rebranded ViGEm" is still only the reporter's account. The handle release is inspected rather than measured; with Steam closed there was nothing to contend for it.

Two follow-ups found along the way and deliberately left out: #66 still carries the wrong-bus theory, which this work disproved (the forks change the interface GUID and are invisible to the client), and `%ls` truncation remains in `DeviceRestart`'s holder, veto-name and scan-info log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
