### PR TITLE
Keep a log line from ending at its first non-ASCII character

### DIFF
--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -201,22 +201,6 @@ void ControllerManager::EmergencyRestoreAll() noexcept {
     }
 }
 
-// EventLog's %ls reaches fprintf, which converts wide characters through the C
-// locale and silently abandons the rest of the line at the first one it cannot
-// encode. Measured: a bus report ending in an em dash logged as its first
-// clause and nothing else. Device names on a localised Windows will do the
-// same, so hand the log UTF-8 bytes and let %s pass them through untouched.
-static std::string Utf8(const std::wstring& text) {
-    if (text.empty()) return {};
-    const int bytes = WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1,
-                                          nullptr, 0, nullptr, nullptr);
-    if (bytes <= 1) return {};
-    std::string out(static_cast<size_t>(bytes), '\0');
-    WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1, out.data(), bytes, nullptr, nullptr);
-    out.resize(static_cast<size_t>(bytes) - 1);  // drop the terminator
-    return out;
-}
-
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -563,7 +547,7 @@ ControllerManager::EnableGameModeSlot(Slot& slot, bool& padUnavailableOut,
         // otherwise inexplicable connect failure and the hardest thing to
         // guess at from the outside, so it goes in the log every time.
         if (!slot.vc->BusReport().empty()) {
-            EventLog::Write("GAMEMODE: %s", Utf8(slot.vc->BusReport()).c_str());
+            EventLog::Write("GAMEMODE: %ls", slot.vc->BusReport().c_str());
             m_lastBusReport = slot.vc->BusReport();
         }
         m_lastPadDriverMissing = slot.vc->IsDriverMissing();

--- a/src/app/EventLog.h
+++ b/src/app/EventLog.h
@@ -8,6 +8,10 @@
 // events.old.log at ~512 KB, so it can run forever without growing unbounded.
 //
 // Thread-safe. printf-style formatting; use %ls for wide strings (paths).
+//
+// %ls only survives non-ASCII because wWinMain sets LC_CTYPE to UTF-8 — see
+// the note there. Without it fprintf abandons the line partway through rather
+// than reporting an error.
 namespace EventLog {
 
 // Annotated so the compiler type-checks every format string against its

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,7 +1,23 @@
 #include "TrayApp.h"
 #include <Windows.h>
+#include <clocale>
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR, int) {
+    // The event log formats wide strings with %ls, which fprintf converts
+    // through the C locale — and the default one encodes nothing above ASCII.
+    // It does not fail loudly either: it abandons the line at the first
+    // character it cannot encode, so a log line silently loses everything from
+    // there on. Measured: a bus report ending in an em dash wrote its opening
+    // clause and stopped mid-sentence.
+    //
+    // Which matters because the values most likely to carry non-ASCII are the
+    // ones worth reading — a game's name, a foreground window, the process
+    // holding the controller, a device's friendly name on a localised Windows.
+    // LC_CTYPE alone, so number and date formatting keep the C locale's
+    // behaviour, and here at the top so it lands before the first log line and
+    // before any thread exists to race it.
+    setlocale(LC_CTYPE, ".UTF8");
+
     // Enable per-monitor v2 DPI awareness so the WebView2 window renders crisp
     // on high-DPI displays and the WM_NCHITTEST pixel math stays correct.
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);

--- a/src/helper/DeviceCycleHelper.cpp
+++ b/src/helper/DeviceCycleHelper.cpp
@@ -20,6 +20,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <clocale>
 #include <cstdarg>
 #include <cstdio>
 #include <string>
@@ -332,6 +333,11 @@ static int FindHoldersOnly() {
 }
 
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR cmdLine, int) {
+    // cycle.log has the same %ls problem the event log does, and more to lose
+    // by it: the holder lists and veto names it exists to record are exactly
+    // the values that carry non-ASCII. See the note in the tray app's main.
+    setlocale(LC_CTYPE, ".UTF8");
+
     if (cmdLine && wcsstr(cmdLine, L"--register"))     return RegisterTask();
     if (cmdLine && wcsstr(cmdLine, L"--unregister"))   return UnregisterTask();
     if (cmdLine && wcsstr(cmdLine, L"--find-holders")) return FindHoldersOnly();


### PR DESCRIPTION
Follow-up to #70, which fixed this at one call site and left the rest.

## The bug

Both logs format wide strings with `%ls`, which `fprintf` converts through the C locale. The default locale encodes nothing above ASCII, and when it meets something it cannot encode it does not fail — it abandons the rest of the line. Measured with the same call shape `EventLog::Write` uses:

```
default  : [before
utf8ctype: [before — after éü]
```

The first line is the entire output. No closing bracket, no newline, no error return.

## Why it matters beyond the one line already patched

Device paths are ASCII by construction, which is the only reason this went unnoticed. Every *other* wide value in these logs is one that can carry non-ASCII, and they're the ones worth reading:

- `PROFILE: switched to` — game names
- `INJECT: foreground=` — window titles and executable paths, which contain the user's name
- `ACQUIRE: holder scan` / `processes holding the device open` / `holders=` — process and device friendly names
- the helper's `cycle.log`: `HOLDERS:`, `SCAN:`, `FIND:`, veto names

These are the lines a maintainer reads first when a controller cannot be claimed, and on a localized Windows they can end mid-sentence with nothing to say they did.

## The fix

`setlocale(LC_CTYPE, ".UTF8")` at both entry points. That fixes every site at once, including ones not yet written — which converting the fifteen existing call sites would not. `LC_CTYPE` only, so number and date formatting keep the C locale's behavior, and at the top of `wWinMain` so it lands before the first log line and before any thread exists to race it.

The local converter added alongside the bus report in #70 goes away with it, so there's one mechanism rather than two.

## Verification

The mechanism is proven directly by the measurement above. The app starts and logs normally afterwards, with ASCII paths rendering as before.

Not re-verified end to end: triggering a genuinely non-ASCII log line means disabling the ViGEm bus again to get the em dash back in the bus report, which didn't seem worth the device surgery for a logging change. That line *was* verified end to end in #70 and now rests on the locale call instead.

No console fallout — both binaries are `WIN32` subsystem with nowhere to print, and the console probes are separate executables that don't set the locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
