### PR TITLE
Add an auto mode that runs only for games with a profile

### DIFF
--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.15"
+#define MyAppVersion "1.17"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/src/app/GameProfiles.cpp
+++ b/src/app/GameProfiles.cpp
@@ -61,6 +61,9 @@ std::map<std::wstring, ControllerProfile> Load() {
         if (!id.empty()) {
             ControllerProfile p;
             p.displayName = ReadSz(child, L"Name");
+            // Absent on every profile written before followers existed, and 0
+            // is "has its own controls" precisely so those keep theirs.
+            p.useDefaultMappings = ReadDw(child, L"UseDefaultMappings", 0) != 0;
             p.platform = ReadDw(child, L"Platform", 0) != 0 ? ControllerPlatform::PlayStation
                                                             : ControllerPlatform::Xbox;
             p.back.l4 = BackButtonBinding::Unpack(ReadDw(child, L"L4", unbound));
@@ -101,6 +104,9 @@ void Save(const std::map<std::wstring, ControllerProfile>& profiles) {
                             KEY_WRITE, nullptr, &child, nullptr) == ERROR_SUCCESS) {
             WriteSz(child, L"Id", id);
             WriteSz(child, L"Name", p.displayName);
+            // The controls below are written either way, so a profile that
+            // stops following the default still has whatever it had before.
+            WriteDw(child, L"UseDefaultMappings", p.useDefaultMappings ? 1 : 0);
             WriteDw(child, L"Platform",
                     p.platform == ControllerPlatform::PlayStation ? 1 : 0);
             WriteDw(child, L"L4", p.back.l4.Pack());

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -63,6 +63,8 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 .inherit-row input{width:16px;height:16px;accent-color:#4a9eff;cursor:pointer;flex:none;margin:0;}
 .inherit-row label{font-size:13.5px;color:#aeb9c2;font-weight:500;cursor:pointer;}
 .inherit-note{font-size:12px;color:#7d8b96;padding:8px 0 14px 26px;line-height:1.45;}
+.combo-badge{margin-left:8px;font-size:10px;font-weight:700;letter-spacing:.6px;color:#c9a86a;border:1px solid rgba(201,168,106,.35);border-radius:3px;padding:1px 5px;}
+.missing-note{margin-top:11px;font-size:12px;color:#c9a86a;line-height:1.45;}
 /* Following the default leaves nothing below worth reading as editable. */
 #settings.inherited{opacity:.38;pointer-events:none;}
 .connector{flex:1;height:1.5px;border-top:1.5px dashed rgba(255,255,255,.1);}
@@ -167,6 +169,7 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
         <div id="combo-results"></div>
       </div>
     </div>
+    <div class="missing-note" id="missing-note" style="display:none;">This game wasn't found on this PC. Its profile is kept, and will start working again if the game comes back. Delete this if the game won't be coming back.</div>
   </div>
   <div class="group" id="inherit-group" style="display:none;">
     <div class="group-label">MAPPINGS</div>
@@ -626,6 +629,11 @@ function removeCurrent(){
   var gone=currentGame;
   var p={}; for(var k in PROFILES) if(k!==gone) p[k]=PROFILES[k];
   PROFILES=p;
+  // An entry that existed only because a profile pointed at it goes with the
+  // profile. Left behind it stops being pinned, and the only section it could
+  // then appear in is the one labelled INSTALLED GAMES, which it never was.
+  if(gameMissing(gone))
+    GAMES=GAMES.filter(function(g){return g.id!==gone;});
   postMsg({type:'delete',game:gone});
   selectGame('');
   renderCombo();  // it stops being a pinned entry
@@ -670,7 +678,7 @@ function renderCombo(){
     html+='<div class="combo-section-label">PROFILES</div><div class="combo-list">';
     if(showDefault)
       html+=itemHTML('','Default (all other games)');
-    pinned.forEach(function(g){html+=itemHTML(g.id,g.name);});
+    pinned.forEach(function(g){html+=itemHTML(g.id,g.name,g.missing==='1');});
     html+='</div>';
   }
 
@@ -682,7 +690,7 @@ function renderCombo(){
     }).slice(0,50);  // a two-letter query can match hundreds; cap the DOM work
     if(matches.length){
       html+='<div class="combo-section-label">INSTALLED GAMES</div><div class="combo-list">';
-      matches.forEach(function(g){html+=itemHTML(g.id,g.name);});
+      matches.forEach(function(g){html+=itemHTML(g.id,g.name,g.missing==='1');});
       html+='</div>';
     } else if(!pinned.length&&!showDefault){
       html+='<div class="combo-empty">No games match "'+escapeHTML(comboQuery)+'"</div>';
@@ -691,9 +699,15 @@ function renderCombo(){
 
   results.innerHTML=html;
 }
-function itemHTML(id,name){
+function itemHTML(id,name,missing){
   var cls='combo-item'+(id===currentGame?' active':'');
-  return '<div class="'+cls+'" onclick="pickGame(\''+id+'\')">'+escapeHTML(name)+'</div>';
+  var badge=missing?'<span class="combo-badge">NOT INSTALLED</span>':'';
+  return '<div class="'+cls+'" onclick="pickGame(\''+id+'\')">'+escapeHTML(name)+badge+'</div>';
+}
+// True for a picker entry that exists only because a profile refers to it.
+function gameMissing(gameId){
+  for(var i=0;i<GAMES.length;i++) if(GAMES[i].id===gameId) return GAMES[i].missing==='1';
+  return false;
 }
 function escapeHTML(s){
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;')
@@ -767,6 +781,10 @@ function renderInherit(){
   var del=document.getElementById('btn-delete');
   if(del) del.style.display=
     (currentGame!==''&&PROFILES.hasOwnProperty(currentGame))?'':'none';
+  // Says why this game is reachable at all when it is not on the PC, and that
+  // its profile is being kept rather than quietly ignored.
+  var miss=document.getElementById('missing-note');
+  if(miss) miss.style.display=(currentGame!==''&&gameMissing(currentGame))?'':'none';
 }
 function renderModeSelects(){
   renderInherit();
@@ -1154,6 +1172,36 @@ RemapWindow::~RemapWindow() {
     s_instance = nullptr;
 }
 
+void RemapWindow::AppendOrphanProfiles() {
+    m_installedCount = m_games.size();
+
+    // An enumeration that found nothing at all looks exactly like every game
+    // having been uninstalled, and is by far the likelier of the two — a COM
+    // failure reading shell:AppsFolder, or a Start Menu walk that came back
+    // empty. Flagging every profile as missing on that evidence would invite
+    // the user to delete the lot, so say nothing rather than guess.
+    if (m_games.empty()) return;
+
+    for (const auto& [id, profile] : m_gameProfiles) {
+        bool installed = false;
+        for (size_t i = 0; i < m_installedCount; ++i) {
+            if (_wcsicmp(m_games[i].id.c_str(), id.c_str()) == 0) {
+                installed = true;
+                break;
+            }
+        }
+        if (installed) continue;
+
+        InstalledGame orphan;
+        orphan.id = id;
+        // What displayName was stored for: naming a profile at a moment the
+        // installed list cannot. Profiles written before it existed fall back
+        // to the raw id — poor prose, but it still identifies the game.
+        orphan.name = profile.displayName.empty() ? id : profile.displayName;
+        m_games.push_back(std::move(orphan));
+    }
+}
+
 void RemapWindow::Open(HINSTANCE hInst, ControllerManager* mgr,
                        const ControllerProfile& cfg,
                        std::vector<InstalledGame> games,
@@ -1170,6 +1218,7 @@ void RemapWindow::Open(HINSTANCE hInst, ControllerManager* mgr,
         m_gameProfiles  = std::move(gameProfiles);
         m_applyCallback = std::move(applyCallback);
         m_deleteCallback = std::move(deleteCallback);
+        AppendOrphanProfiles();
         ShowWindow(m_hwnd, SW_SHOW);
         BringToFront();
         SendInitState();
@@ -1194,6 +1243,7 @@ void RemapWindow::Open(HINSTANCE hInst, ControllerManager* mgr,
     m_gameProfiles = std::move(gameProfiles);
     m_applyCallback = std::move(applyCallback);
     m_deleteCallback = std::move(deleteCallback);
+    AppendOrphanProfiles();
     s_instance     = this;
 
     // --- Register window class (once) ---
@@ -1586,7 +1636,9 @@ void RemapWindow::SendInitState() {
     for (size_t i = 0; i < m_games.size(); ++i) {
         if (!gamesJson.empty()) gamesJson += L",";
         gamesJson += L"{\"id\":\"" + std::to_wstring(i) + L"\",\"name\":\""
-                   + JsonEscape(m_games[i].name) + L"\"}";
+                   + JsonEscape(m_games[i].name) + L"\""
+                   + (i >= m_installedCount ? L",\"missing\":\"1\"" : L"")
+                   + L"}";
     }
 
     // Profiles: the default plus every game that already has a saved

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -59,6 +59,12 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 .badge-id{font-size:15px;font-weight:800;color:#fff;line-height:1;}
 .badge-pos{font-family:'JetBrains Mono',monospace;font-size:8px;color:#5c6b78;letter-spacing:.5px;margin-top:2px;}
 .pos-label{font-size:13.5px;color:#aeb9c2;font-weight:500;flex:none;}
+.inherit-row{display:flex;align-items:center;gap:10px;padding:14px 0 0 0;}
+.inherit-row input{width:16px;height:16px;accent-color:#4a9eff;cursor:pointer;flex:none;margin:0;}
+.inherit-row label{font-size:13.5px;color:#aeb9c2;font-weight:500;cursor:pointer;}
+.inherit-note{font-size:12px;color:#7d8b96;padding:8px 0 14px 26px;line-height:1.45;}
+/* Following the default leaves nothing below worth reading as editable. */
+#settings.inherited{opacity:.38;pointer-events:none;}
 .connector{flex:1;height:1.5px;border-top:1.5px dashed rgba(255,255,255,.1);}
 .row-right{display:flex;align-items:center;gap:11px;flex:none;}
 .chip-lg{width:32px;height:32px;border-radius:8px;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:13px;flex:none;}
@@ -118,6 +124,14 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 .btn-discard:hover{border-color:#c0392b;color:#fff;}
 .btn-modal-cancel{padding:8px 15px;border-radius:4px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.04);color:#aeb9c2;font-weight:600;font-size:13px;}
 .btn-modal-cancel:hover{color:#fff;}
+.btn-modal-delete{padding:8px 15px;border-radius:4px;border:none;background:#a33a3a;color:#fff;font-weight:700;font-size:13px;}
+.btn-modal-delete:hover{opacity:.9;}
+/* Same treatment as Apply — padding, radius, inset highlight — so it reads as
+   a peer of it rather than as a warning, but coloured for what it does. The
+   footer is space-between, so it sits at the far end from Apply: separated by
+   the whole width of the window rather than by a gap somebody can misjudge. */
+.btn-delete{padding:9px 16px;border-radius:3px;border:1px solid #7a2626;background:linear-gradient(to bottom,#b34141,#8a2727);color:#fff;font-weight:700;font-size:13.5px;box-shadow:0 1px 0 rgba(255,255,255,.18) inset;transition:opacity .15s;}
+.btn-delete:hover{opacity:.9;}
 .btn-save{padding:8px 18px;border-radius:4px;border:1px solid #4c7a1d;background:linear-gradient(to bottom,#94c63d,#5d8a1f);color:#13260a;font-weight:700;font-size:13px;}
 .btn-save:hover{opacity:.9;}
 </style>
@@ -154,6 +168,15 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
       </div>
     </div>
   </div>
+  <div class="group" id="inherit-group" style="display:none;">
+    <div class="group-label">MAPPINGS</div>
+    <div class="inherit-row">
+      <input type="checkbox" id="use-default">
+      <label for="use-default">Use my default mappings</label>
+    </div>
+    <div class="inherit-note">This game turns the controller on and uses the controls from your default profile, including any later changes to it. Uncheck to give this game controls of its own.</div>
+  </div>
+  <div id="settings">
   <div class="group">
     <div class="group-label">CONTROLLER PLATFORM</div>
     <div class="row mode-row">
@@ -210,6 +233,7 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
     <div id="row-R4" class="row"></div>
     <div id="row-R5" class="row"></div>
   </div>
+  </div>
 </div>
 
 <div id="footer">
@@ -217,16 +241,18 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
     <button class="btn-reset" id="btn-reset">Reset this profile to default</button>
     <button class="btn-apply" id="btn-apply">Apply</button>
   </div>
+  <button class="btn-delete" id="btn-delete" style="display:none;">Delete Profile</button>
 </div>
 
 <div id="modal-backdrop" style="display:none;">
   <div class="modal">
-    <h3>Unsaved changes</h3>
+    <h3 id="modal-title">Unsaved changes</h3>
     <p id="modal-text">You have unsaved changes to this profile.</p>
     <div class="modal-btns">
       <button class="btn-modal-cancel" id="btn-modal-cancel">Cancel</button>
       <button class="btn-discard" id="btn-modal-discard">Discard</button>
       <button class="btn-save" id="btn-modal-save">Save</button>
+      <button class="btn-modal-delete" id="btn-modal-delete" style="display:none;">Delete</button>
     </div>
   </div>
 </div>
@@ -256,6 +282,9 @@ var modes = {LPAD:'none',RPAD:'none'};
 // every pad so switching modes back and forth does not lose the choice.
 var dirs = {LPAD:'natural',RPAD:'natural'};
 var platform = 'xbox';
+// This game follows the default profile's controls instead of carrying its
+// own. Only ever true for a game — the default has nothing to follow.
+var useDefault = false;
 // The DS4 touchpad only exists on a virtual PlayStation pad — an X360 report
 // has nothing to carry it. The option stays selectable either way (a profile
 // can legitimately be edited before its platform is), but it says so, and
@@ -495,7 +524,7 @@ function applyBindings(){
 }
 // Flatten the live editor state into the stored/wire profile shape.
 function currentProfile(){
-  var p={platform:platform};
+  var p={useDefault:useDefault?'1':'0',platform:platform};
   ROWS.forEach(function(r){p[r.id]=bindings[r.id];});
   PADS.forEach(function(x){p[x+'mode']=modes[x];p[x+'dir']=dirs[x];});
   return p;
@@ -505,6 +534,15 @@ function currentProfile(){
 // settings existed has no pad entries, and reads as the unclaimed default.
 function loadProfileInto(p){
   platform=p.hasOwnProperty('platform')?p.platform:DEFAULT_PLATFORM;
+  // A game we have never saved starts out following the default rather than
+  // forking a copy of it: under "off unless a game profile is running" most
+  // profiles exist only to turn the controller on, and a fork made for that
+  // reason stops tracking the default the moment it is created. A game that
+  // has been saved keeps whatever it was saved as, and the default profile
+  // itself can never follow anything.
+  useDefault = currentGame!=='' && (PROFILES.hasOwnProperty(currentGame)
+                                      ? p.useDefault==='1'
+                                      : true);
   bindings={};
   ROWS.forEach(function(r){
     bindings[r.id]=p.hasOwnProperty(r.id)?p[r.id]:DEFAULTS[r.id];
@@ -529,7 +567,8 @@ function saveCurrent(){
   msg.type='apply';
   msg.game=currentGame;
   postMsg(msg);
-  renderCombo();  // a newly saved game becomes a pinned entry
+  renderCombo();   // a newly saved game becomes a pinned entry
+  renderInherit(); // and gains a profile that can now be removed
 }
 
 // ---- Unsaved-changes guard ----
@@ -542,21 +581,54 @@ function isDirty(){
 // Run `action`, but if the current profile has unsaved edits, ask first.
 // Every path that would abandon those edits \u2014 switching selection, closing
 // the window \u2014 goes through here rather than duplicating the prompt.
+// One modal serves both prompts rather than two sharing the screen: Escape,
+// the backdrop and the keydown handler all have to know about exactly one
+// thing that can sit on top of everything else, and a second backdrop would
+// have to be taught to every one of them.
+function showModal(mode,title,text){
+  var del=(mode==='delete');
+  document.getElementById('modal-title').textContent=title;
+  document.getElementById('modal-text').textContent=text;
+  document.getElementById('btn-modal-discard').style.display=del?'none':'';
+  document.getElementById('btn-modal-save').style.display=del?'none':'';
+  document.getElementById('btn-modal-delete').style.display=del?'':'none';
+  document.getElementById('modal-backdrop').style.display='flex';
+}
 function guard(action){
   if(!isDirty()){action();return;}
   pendingAction=action;
   var name=currentGame===''?'the default profile':(gameName(currentGame)||'this game');
-  document.getElementById('modal-text').textContent=
-    'You have unsaved changes to '+name+'. Save them before continuing?';
-  document.getElementById('modal-backdrop').style.display='flex';
+  showModal('unsaved','Unsaved changes',
+            'You have unsaved changes to '+name+'. Save them before continuing?');
+}
+function confirmRemove(){
+  if(currentGame==='') return;  // the default profile is not removable
+  showModal('delete','Delete this profile?',
+            'The profile for '+(gameName(currentGame)||'this game')+
+            ' will be deleted. It will go back to default behavior.');
 }
 function resolveModal(choice){
   document.getElementById('modal-backdrop').style.display='none';
   var action=pendingAction;
   pendingAction=null;
   if(choice==='cancel') return;
+  // Delete opens on its own rather than in front of a pending action, so there
+  // is never one waiting behind it to run afterwards.
+  if(choice==='delete'){removeCurrent();return;}
   if(choice==='save') saveCurrent();
   if(action) action();
+}
+// Drop the selected game's profile and fall back to the default. Edits in
+// flight go with it — the user just said to throw the profile away, so asking
+// again about unsaved changes to it would be asking about nothing.
+function removeCurrent(){
+  if(currentGame==='') return;
+  var gone=currentGame;
+  var p={}; for(var k in PROFILES) if(k!==gone) p[k]=PROFILES[k];
+  PROFILES=p;
+  postMsg({type:'delete',game:gone});
+  selectGame('');
+  renderCombo();  // it stops being a pinned entry
 }
 )HTML"
 // Second split, same C2026 limit as above — the script outgrew one literal
@@ -677,7 +749,27 @@ function setPlatform(value){
   // have to be rebuilt rather than left as they are.
   renderModeSelects();
 }
+// The checkbox belongs to a game, never to the default profile, and while it
+// is ticked everything below it describes controls this game is not using —
+// so the settings are dimmed and inert, and "reset this profile" with them.
+function renderInherit(){
+  var group=document.getElementById('inherit-group');
+  if(group) group.style.display=(currentGame==='')?'none':'';
+  var box=document.getElementById('use-default');
+  if(box) box.checked=useDefault;
+  var settings=document.getElementById('settings');
+  if(settings) settings.className=(currentGame!==''&&useDefault)?'inherited':'';
+  var reset=document.getElementById('btn-reset');
+  if(reset) reset.disabled=(currentGame!==''&&useDefault);
+  // Only offered for a game that actually has something saved — a game merely
+  // being looked at has no profile to delete. Hidden rather than disabled so
+  // the footer holds nothing red at all for the default profile.
+  var del=document.getElementById('btn-delete');
+  if(del) del.style.display=
+    (currentGame!==''&&PROFILES.hasOwnProperty(currentGame))?'':'none';
+}
 function renderModeSelects(){
+  renderInherit();
   fillSelect('platform',PLATFORM_OPTIONS,platform);
   var opts=modeOptions();
   PADS.forEach(function(padId){
@@ -779,6 +871,13 @@ document.getElementById('btn-close').onclick=function(){guard(function(){postMsg
 document.getElementById('btn-reset').onclick=resetDefaults;
 document.getElementById('btn-apply').onclick=applyBindings;
 
+document.getElementById('use-default').addEventListener('change',function(e){
+  useDefault=e.target.checked;
+  // Unticking must stop any capture already running underneath the dimmed
+  // rows, and reveals whatever controls this game had stored all along.
+  cancelListening();
+  renderInherit();
+});
 document.getElementById('platform').addEventListener('change',function(e){
   setPlatform(e.target.value);
 });
@@ -815,6 +914,8 @@ document.addEventListener('mousedown',function(){
 document.getElementById('btn-modal-cancel').onclick=function(){resolveModal('cancel');};
 document.getElementById('btn-modal-discard').onclick=function(){resolveModal('discard');};
 document.getElementById('btn-modal-save').onclick=function(){resolveModal('save');};
+document.getElementById('btn-modal-delete').onclick=function(){resolveModal('delete');};
+document.getElementById('btn-delete').onclick=confirmRemove;
 
 // Title bar drag: mousedown on titlebar (but not on buttons) tells C++ to start a window move.
 document.getElementById('titlebar').addEventListener('mousedown',function(e){
@@ -1057,7 +1158,8 @@ void RemapWindow::Open(HINSTANCE hInst, ControllerManager* mgr,
                        const ControllerProfile& cfg,
                        std::vector<InstalledGame> games,
                        std::map<std::wstring, ControllerProfile> gameProfiles,
-                       std::function<void(const std::wstring&, const ControllerProfile&)> applyCallback)
+                       std::function<void(const std::wstring&, const ControllerProfile&)> applyCallback,
+                       std::function<void(const std::wstring&)> deleteCallback)
 {
     // If already open, just bring it to front.
     if (m_hwnd) {
@@ -1067,6 +1169,7 @@ void RemapWindow::Open(HINSTANCE hInst, ControllerManager* mgr,
         m_games         = std::move(games);
         m_gameProfiles  = std::move(gameProfiles);
         m_applyCallback = std::move(applyCallback);
+        m_deleteCallback = std::move(deleteCallback);
         ShowWindow(m_hwnd, SW_SHOW);
         BringToFront();
         SendInitState();
@@ -1090,6 +1193,7 @@ void RemapWindow::Open(HINSTANCE hInst, ControllerManager* mgr,
     m_games        = std::move(games);
     m_gameProfiles = std::move(gameProfiles);
     m_applyCallback = std::move(applyCallback);
+    m_deleteCallback = std::move(deleteCallback);
     s_instance     = this;
 
     // --- Register window class (once) ---
@@ -1272,6 +1376,26 @@ static std::string JsonStr(const std::string& json, const std::string& key) {
     return end != std::string::npos ? json.substr(pos, end - pos) : std::string{};
 }
 
+// The page names a game by its index into m_games (ASCII decimal), never by
+// the raw game id — that can hold non-ASCII this hand-rolled channel would
+// mangle, and backslashes this parser does not unescape. Shared by "apply"
+// and "delete" so there is one place that decides what a valid index is.
+//
+// False for an absent index, which "apply" reads as the default profile, and
+// equally for a malformed or out-of-range one, which is a message we did not
+// send and neither handler acts on.
+static bool GameIndexFrom(const std::string& value, size_t count, size_t& out) {
+    if (value.empty()) return false;
+    size_t idx = 0;
+    for (char c : value) {
+        if (c < '0' || c > '9') return false;
+        idx = idx * 10 + static_cast<size_t>(c - '0');
+    }
+    if (idx >= count) return false;
+    out = idx;
+    return true;
+}
+
 void RemapWindow::OnWebMessage(const std::wstring& raw) {
     // All message content is ASCII; narrow explicitly to suppress C4244.
     std::string msg;
@@ -1339,6 +1463,9 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
         // The page sends one flat object: a binding per row id, plus a mode
         // per pad.
         ControllerProfile cfg;
+        // The page sends "0" for the default profile, which cannot follow
+        // anything — so this needs no special case for it here.
+        cfg.useDefaultMappings = JsonStr(msg, "useDefault") == "1";
         cfg.platform = JsonStr(msg, "platform") == "ps" ? ControllerPlatform::PlayStation
                                                         : ControllerPlatform::Xbox;
         cfg.back.l4 = BackButtonBinding::FromId(JsonStr(msg, "L4"));
@@ -1352,29 +1479,33 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
         cfg.leftPad.scrollDir  = ScrollDirectionFromId(JsonStr(msg, "LPADdir"));
         cfg.rightPad.scrollDir = ScrollDirectionFromId(JsonStr(msg, "RPADdir"));
 
-        // "game" is an index into m_games (ASCII decimal), never the raw
-        // game id — that can contain non-ASCII characters this hand-rolled
-        // channel would mangle, and backslashes this parser does not unescape.
-        const std::string gameIdx = JsonStr(msg, "game");
-        if (gameIdx.empty()) {
-            m_config = cfg;
-            if (m_applyCallback) m_applyCallback(L"", cfg);
+        size_t idx = 0;
+        if (!GameIndexFrom(JsonStr(msg, "game"), m_games.size(), idx)) {
+            // No index at all is the default profile; a bad one is a message
+            // we did not send and will not act on.
+            if (JsonStr(msg, "game").empty()) {
+                m_config = cfg;
+                if (m_applyCallback) m_applyCallback(L"", cfg);
+            }
         } else {
-            size_t idx = 0;
-            bool valid = true;
-            for (char c : gameIdx) {
-                if (c < '0' || c > '9') { valid = false; break; }
-                idx = idx * 10 + static_cast<size_t>(c - '0');
-            }
-            if (valid && idx < m_games.size()) {
-                const std::wstring& gameId = m_games[idx].id;
-                // Captured here because this is the only place both halves
-                // are in hand: the picker knows the friendly name, and
-                // nothing downstream re-enumerates the installed list.
-                cfg.displayName = m_games[idx].name;
-                m_gameProfiles[gameId] = cfg;
-                if (m_applyCallback) m_applyCallback(gameId, cfg);
-            }
+            const std::wstring& gameId = m_games[idx].id;
+            // Captured here because this is the only place both halves
+            // are in hand: the picker knows the friendly name, and
+            // nothing downstream re-enumerates the installed list.
+            cfg.displayName = m_games[idx].name;
+            m_gameProfiles[gameId] = cfg;
+            if (m_applyCallback) m_applyCallback(gameId, cfg);
+        }
+
+    } else if (type == "delete") {
+        // Never carries an empty index: the page does not offer removal for
+        // the default profile, which has to exist for anything else to fall
+        // back to.
+        size_t idx = 0;
+        if (GameIndexFrom(JsonStr(msg, "game"), m_games.size(), idx)) {
+            const std::wstring& gameId = m_games[idx].id;
+            m_gameProfiles.erase(gameId);
+            if (m_deleteCallback) m_deleteCallback(gameId);
         }
     }
 }
@@ -1406,7 +1537,10 @@ void RemapWindow::SendInitState() {
     // One flat object per profile — the page reads it back the same way, and
     // the narrow JSON reader on this side cannot descend into nesting.
     auto profileJson = [&](const ControllerProfile& p) {
-        return L"{\"platform\":\""
+        return L"{\"useDefault\":\""
+               + std::wstring(p.useDefaultMappings ? L"1" : L"0")
+               + L"\","
+               L"\"platform\":\""
                + std::wstring(p.platform == ControllerPlatform::PlayStation ? L"ps" : L"xbox")
                + L"\","
                L"\"L4\":\"" + wid(p.back.l4) + L"\","

--- a/src/app/RemapWindow.h
+++ b/src/app/RemapWindow.h
@@ -26,10 +26,14 @@ public:
     // overrides already exist for entries in it. applyCallback fires on the
     // UI thread when the user clicks Apply — the game id identifies whichever
     // game was selected, or is empty for the default profile.
+    // deleteCallback fires when the user removes a game's profile; its id is
+    // one that was in gameProfiles, and never empty — the default profile
+    // cannot be removed.
     void Open(HINSTANCE hInst, ControllerManager* mgr, const ControllerProfile& profile,
               std::vector<InstalledGame> games,
               std::map<std::wstring, ControllerProfile> gameProfiles,
-              std::function<void(const std::wstring&, const ControllerProfile&)> applyCallback);
+              std::function<void(const std::wstring&, const ControllerProfile&)> applyCallback,
+              std::function<void(const std::wstring&)> deleteCallback);
 
     void BringToFront() const;
     // Open in the sense that matters to callers: visible and being edited.
@@ -71,6 +75,7 @@ private:
     std::vector<InstalledGame>                 m_games;
     std::map<std::wstring, ControllerProfile>  m_gameProfiles;
     std::function<void(const std::wstring&, const ControllerProfile&)> m_applyCallback;
+    std::function<void(const std::wstring&)> m_deleteCallback;
     std::function<void()> m_onClose;
 
     Microsoft::WRL::ComPtr<ICoreWebView2Environment> m_env;

--- a/src/app/RemapWindow.h
+++ b/src/app/RemapWindow.h
@@ -50,6 +50,13 @@ private:
     static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
     LRESULT HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
 
+    // Add a picker entry for every saved profile whose game is not in the
+    // installed list, so a profile for something no longer on the PC can
+    // still be reached — to look at, or to delete. Sets m_installedCount to
+    // where the real entries stop, which is the only thing separating the two
+    // kinds afterwards.
+    void AppendOrphanProfiles();
+
     void CreateWebViewAsync(HWND hwnd);
     void OnControllerReady(ICoreWebView2Controller* ctrl);
     void OnWebMessage(const std::wstring& raw);
@@ -72,7 +79,14 @@ private:
     HINSTANCE         m_hInst   = nullptr;
     ControllerManager* m_mgr    = nullptr;
     ControllerProfile m_config;
+    // Installed games first, then one entry per orphaned profile. The page
+    // names games by index into this, so appending rather than keeping a
+    // second list is what lets an orphan be applied and deleted through the
+    // paths that already existed.
     std::vector<InstalledGame>                 m_games;
+    // Where the installed entries stop. Everything at or past it is a profile
+    // whose game we could not find.
+    size_t                                     m_installedCount = 0;
     std::map<std::wstring, ControllerProfile>  m_gameProfiles;
     std::function<void(const std::wstring&, const ControllerProfile&)> m_applyCallback;
     std::function<void(const std::wstring&)> m_deleteCallback;

--- a/src/app/TrackpadConfig.h
+++ b/src/app/TrackpadConfig.h
@@ -117,6 +117,22 @@ struct ControllerProfile {
     // not one of the settings the profile applies.
     std::wstring displayName;
 
+    // This profile carries no controls of its own and follows the default
+    // profile instead. Meaningful only on a per-game profile — the default has
+    // nothing above it to follow, and never sets this.
+    //
+    // Exists because the "off unless a game profile is running" mode made
+    // profiles routine rather than rare: most now exist only to turn the
+    // controller on for a game, and forking a whole copy of the default's
+    // bindings to say that stranded them the moment the default improved.
+    // Everything below is still stored while this is set, so unticking it in
+    // the UI gives the game back the controls it had.
+    //
+    // False by default: every profile written before this existed had controls
+    // of its own, and reading those back as followers would silently discard
+    // them.
+    bool useDefaultMappings = false;
+
     // Which kind of virtual pad the game sees. Unlike everything else here
     // this cannot be changed in place — the ViGEm target is created as one
     // type or the other — so applying a profile that changes it tears the
@@ -136,7 +152,8 @@ struct ControllerProfile {
     };
 
     bool operator==(const ControllerProfile& o) const {
-        return platform == o.platform
+        return useDefaultMappings == o.useDefaultMappings
+            && platform == o.platform
             && back.l4 == o.back.l4 && back.l5 == o.back.l5
             && back.r4 == o.back.r4 && back.r5 == o.back.r5
             && leftPad == o.leftPad && rightPad == o.rightPad;

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -442,7 +442,11 @@ void TrayApp::RefreshSteamApps() {
 const ControllerProfile& TrayApp::ActiveProfile() const {
     if (!m_activeGameId.empty()) {
         auto it = m_gameProfiles.find(m_activeGameId);
-        if (it != m_gameProfiles.end()) return it->second;
+        // A profile that follows the default resolves to it here rather than
+        // being copied anywhere, so editing the default reaches every game
+        // following it without touching a single stored profile.
+        if (it != m_gameProfiles.end() && !it->second.useDefaultMappings)
+            return it->second;
     }
     return m_defaultProfile;
 }
@@ -1113,9 +1117,24 @@ void TrayApp::OpenRemapWindow() {
                 m_gameProfiles[gameId] = profile;
                 GameProfiles::Save(m_gameProfiles);
             }
-            // Editing whichever profile happens to be live should be visible
-            // straight away; editing any other one must not disturb it.
-            if (gameId == m_activeGameId) m_controller->SetProfile(profile);
+            // Editing whichever profile is live should be visible straight
+            // away. Asked unconditionally rather than by comparing ids,
+            // because the live profile may not be the edited one but may be
+            // following it — only ActiveProfile knows that, and for anything
+            // genuinely unrelated this resolves to what is already loaded.
+            PushActiveProfile();
+        },
+        [this](const std::wstring& gameId) {
+            m_gameProfiles.erase(gameId);
+            GameProfiles::Save(m_gameProfiles);
+            EventLog::Write("PROFILE: deleted %ls", gameId.c_str());
+            // No control decision here, for the same reason applying makes
+            // none: the window is open and may have a row listening for a
+            // button, and dropping the controller under it would end that
+            // mid-capture. ActiveProfile already resolves a now-missing id to
+            // the default, and closing the window re-evaluates — which is
+            // what lets go of a controller this profile was holding.
+            PushActiveProfile();
         });
 }
 

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -174,6 +174,18 @@ bool TrayApp::Init(HINSTANCE hInstance) {
         EventLog::Write("PROFILE: foreground watcher could not start — "
                         "per-game profiles will not switch by themselves");
 
+    // Resolve what is in front right now. The watcher above only reports
+    // changes, so without this a user who launches us while already sitting
+    // in a game would be judged against the default profile until they next
+    // switched windows — and with a default that hands the controller back,
+    // that means no controller.
+    //
+    // Selection only, no control decision: the first Steam state is still in
+    // flight on the watcher thread, and deciding against the NoSteam it has
+    // not confirmed yet would be guessing.
+    SelectProfile(MatchProfile(ForegroundWatcher::Current()));
+    PushActiveProfile();
+
     return true;
 }
 
@@ -251,6 +263,22 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
                 EnsureCycleTaskRegistered();
             SetAutoMode(AutoMode::OffOnlyInGame);
             break;
+        case IDM_MODE_PROFILE:
+            // Same reason as the mode above: this one can be asked to take the
+            // controller while Steam is running it, and that needs the helper.
+            if (!IsProcessElevated())
+                EnsureCycleTaskRegistered();
+            SetAutoMode(AutoMode::OffUnlessProfile);
+            // With nothing to match, this mode holds the controller for
+            // nothing at all. Said once, on the click, because a controller
+            // that has gone quiet and stays quiet is otherwise indisting-
+            // uishable from the app having broken.
+            if (m_gameProfiles.empty() && m_notificationsEnabled)
+                ShowAlertBalloon(L"No game profiles yet",
+                                 L"The controller stays in its own keyboard/mouse mode "
+                                 L"until you add a profile for a game in Customize Controls.",
+                                 BalloonAction::None, NIIF_INFO);
+            break;
         case IDM_STARTUP:
             m_startupEnabled = !m_startupEnabled;
             UpdateStartupRegistration();
@@ -308,6 +336,12 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             // Cheap probe — we are only asking whether anything woke up.
             if (m_wantControl)
                 TryAcquireController(WAKE_PROBE_MS);
+        } else if (wp == IDT_RELEASE_GRACE) {
+            KillTimer(m_hwnd, IDT_RELEASE_GRACE);
+            // Re-asked rather than assumed: the grace period exists precisely
+            // so the answer can change while it runs, and coming back to the
+            // game is the case it is here for.
+            if (!WantControlNow()) ReleaseControl();
         } else if (wp == IDT_HEARTBEAT) {
             // Periodic, so not killed — its absence is the signal.
             WriteHeartbeat();
@@ -346,7 +380,8 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 }
 
 void TrayApp::SetAutoMode(AutoMode mode) {
-    EventLog::Write("MODE: control mode set to %d (0=manual 1=offWhileSteam 2=offOnlyInGame)",
+    EventLog::Write("MODE: control mode set to %d "
+                    "(0=manual 1=offWhileSteam 2=offOnlyInGame 3=offUnlessProfile)",
                     static_cast<int>(mode));
     m_autoMode = mode;
     m_acquireRetries = 0;
@@ -358,7 +393,7 @@ void TrayApp::SetAutoMode(AutoMode mode) {
         // user's back just because they changed mode.
         m_wantControl = m_controller->IsGameModeActive();
     else
-        ApplySteamState(m_steamWatcher.GetState());
+        EvaluateControl();
 }
 
 // ---------------------------------------------------------------------------
@@ -404,68 +439,89 @@ void TrayApp::RefreshSteamApps() {
                     m_steamApps.Count());
 }
 
-void TrayApp::ActivateProfile(const std::wstring& gameId) {
-    if (gameId == m_activeGameId) return;
-
-    const ControllerProfile* profile = &m_defaultProfile;
-    if (!gameId.empty()) {
-        auto it = m_gameProfiles.find(gameId);
-        // A profile deleted between resolving and applying leaves nothing to
-        // switch to; the default is the right answer, not a stale pointer.
-        if (it == m_gameProfiles.end()) return ActivateProfile({});
-        profile = &it->second;
+const ControllerProfile& TrayApp::ActiveProfile() const {
+    if (!m_activeGameId.empty()) {
+        auto it = m_gameProfiles.find(m_activeGameId);
+        if (it != m_gameProfiles.end()) return it->second;
     }
+    return m_defaultProfile;
+}
+
+bool TrayApp::SelectProfile(const std::wstring& gameId) {
+    if (gameId == m_activeGameId) return false;
+
+    // A profile deleted between resolving and selecting leaves nothing to
+    // switch to; the default is the right answer, not a stale id.
+    if (!gameId.empty() && m_gameProfiles.find(gameId) == m_gameProfiles.end())
+        return SelectProfile({});
 
     m_activeGameId = gameId;
     EventLog::Write("PROFILE: switched to %ls",
                     gameId.empty() ? L"the default profile" : gameId.c_str());
-    m_controller->SetProfile(*profile);
+    return true;
+}
 
-    if (gameId.empty()) return;  // returning to the default is not news
+void TrayApp::PushActiveProfile() {
+    const ControllerProfile& profile = ActiveProfile();
+    m_controller->SetProfile(profile);
+
+    if (m_activeGameId.empty()) return;  // returning to the default is not news
+
+    // Announced only when the profile is actually going to run. Pushing
+    // happens before the control decision, so without this the balloon would
+    // promise a game's custom controls at the same moment we hand the
+    // controller back and provide none.
+    if (!WantControlNow()) return;
 
     // Told once per game rather than on every activation. Alt-tabbing out of
     // a game and back in reloads its profile, and a balloon on each round
     // trip would be noise — the point is to confirm the profile was found at
     // all, which the first one does.
-    if (gameId == m_toastedGameId) return;
-    m_toastedGameId = gameId;
+    if (m_activeGameId == m_toastedGameId) return;
+    m_toastedGameId = m_activeGameId;
 
     if (!m_notificationsEnabled) return;
     // Falls back to the id when the profile predates display names being
     // stored; an exe path is poor prose but it still identifies the game.
-    const std::wstring& name = profile->displayName.empty() ? gameId
-                                                            : profile->displayName;
+    const std::wstring& name = profile.displayName.empty() ? m_activeGameId
+                                                           : profile.displayName;
     ShowAlertBalloon(L"Custom controls loaded",
                      L"Custom controller profile for " + name + L" loaded.",
                      BalloonAction::None, NIIF_INFO);
 }
 
 void TrayApp::OnForegroundChanged(const ForegroundIdentity& id) {
-    // Auto Mode owns whether the controller is ours at all. When it has been
-    // yielded there is no input to rebind — Steam is driving the pad — so
-    // there is nothing here to decide.
-    if (!m_controller->IsGameModeActive()) return;
-
+    // Deliberately not gated on the controller already being ours. With a
+    // default profile that can hand the controller back, this is the path
+    // that decides whether we hold the device at all, so it has to keep
+    // running precisely when we do not — otherwise nothing would ever notice
+    // the game that is supposed to take it back.
+    //
     // The customization window edits one profile while another could be
     // running underneath it. Switching out from under the user mid-edit
     // would apply their changes to the wrong game.
     if (m_remapWindow.IsOpen()) return;
 
-    ActivateProfile(MatchProfile(id));
+    if (!SelectProfile(MatchProfile(id))) return;
+    // Only push a profile we are actually going to run. Applying one changes
+    // the pad in place, but a profile whose platform differs rebuilds the
+    // virtual controller outright — so pushing the default on the way out of
+    // a game replugged the pad under the still-running game within a frame,
+    // five seconds before the grace period below had any say in it. Leaving
+    // whatever is live alone until the release really happens is what makes
+    // alt-tabbing back genuinely free.
+    if (WantControlNow()) PushActiveProfile();
+    EvaluateControl();
 }
 
 void TrayApp::RefreshActiveProfile() {
-    if (!m_controller->IsGameModeActive()) {
-        // Nothing of ours is running; drop back so re-acquiring starts from a
-        // known state rather than from whatever was live when control went.
-        ActivateProfile({});
-        return;
-    }
     if (m_remapWindow.IsOpen()) return;
-    ActivateProfile(MatchProfile(ForegroundWatcher::Current()));
+    SelectProfile(MatchProfile(ForegroundWatcher::Current()));
+    if (WantControlNow()) PushActiveProfile();  // see OnForegroundChanged
+    EvaluateControl();
 }
 
-bool TrayApp::WantControl(SteamState state) const {
+bool TrayApp::SteamAllowsControl(SteamState state) const {
     switch (m_autoMode) {
     case AutoMode::OffWhileSteam: return state == SteamState::NoSteam;
     case AutoMode::OffOnlyInGame: return state != SteamState::InGame;
@@ -473,19 +529,84 @@ bool TrayApp::WantControl(SteamState state) const {
     }
 }
 
-void TrayApp::ApplySteamState(SteamState state) {
-    if (m_autoMode == AutoMode::Manual) return;
+// One question per mode, rather than one answer assembled from several
+// settings that override each other — which is what makes the outcome
+// predictable from the mode name alone.
+bool TrayApp::WantControlNow() const {
+    switch (m_autoMode) {
+    case AutoMode::Manual:
+        // The tray toggle is the only authority here, and nothing else may
+        // turn the controller on behind the user's back.
+        return m_wantControl;
 
-    EventLog::Write("AUTO: steam state %d (0=none 1=idle 2=inGame) -> %s",
-                    static_cast<int>(state),
-                    WantControl(state) ? "take control" : "yield");
-    if (WantControl(state)) {
+    case AutoMode::OffUnlessProfile:
+        // A matched profile is the entire test. Deliberately asked without
+        // consulting Steam: the user made a profile for this game, which is
+        // them saying they want us driving it rather than Steam Input, and
+        // the acquire path already knows how to take the device from a live
+        // Steam. With nothing matched we want nothing, so this mode never
+        // contends with Steam except over games it was told to.
+        return !m_activeGameId.empty();
+
+    default:
+        // The Steam-yielding modes, unchanged: Steam's state is the whole
+        // answer, exactly as it has always been.
+        return SteamAllowsControl(m_steamWatcher.GetState());
+    }
+}
+
+void TrayApp::EvaluateControl() {
+    const bool want = WantControlNow();
+    EventLog::Write("CONTROL: want=%d (mode=%d steam=%d profile=%ls)",
+                    want ? 1 : 0, static_cast<int>(m_autoMode),
+                    static_cast<int>(m_steamWatcher.GetState()),
+                    m_activeGameId.empty() ? L"none" : m_activeGameId.c_str());
+
+    if (want) {
+        // Alt-tabbed back before the grace period ran out — the release that
+        // was pending is simply cancelled, and the pad never went anywhere.
+        KillTimer(m_hwnd, IDT_RELEASE_GRACE);
+        // Already ours, or an acquisition is still in flight. Setting
+        // m_wantControl before TryAcquireController below is also what stops
+        // the RefreshActiveProfile call on its success path re-entering here.
+        if (m_wantControl) return;
         m_wantControl    = true;
         m_acquireRetries = 0;
         TryAcquireController();
-    } else {
-        ReleaseControl();
+        return;
     }
+
+    if (!m_wantControl) return;
+
+    // Steam turning up is the one release that cannot wait: the whole point
+    // of yielding is that Steam is about to open the device, and sitting on
+    // it for another few seconds is what it must not do.
+    //
+    // Only the Steam-yielding modes can be releasing for that reason.
+    // OffUnlessProfile releases because the game stopped being in front,
+    // which is precisely the case the grace period exists for — testing
+    // SteamAllowsControl there would find the `false` it returns for every
+    // mode it does not describe and make every release immediate.
+    const bool yieldingToSteam = (m_autoMode == AutoMode::OffWhileSteam
+                               || m_autoMode == AutoMode::OffOnlyInGame)
+                              && !SteamAllowsControl(m_steamWatcher.GetState());
+    if (yieldingToSteam) {
+        ReleaseControl();
+        return;
+    }
+    SetTimer(m_hwnd, IDT_RELEASE_GRACE, RELEASE_GRACE_MS, nullptr);
+}
+
+void TrayApp::ApplySteamState(SteamState state) {
+    if (m_autoMode == AutoMode::Manual) return;
+
+    // The state only. What to do about it is EvaluateControl's to decide and
+    // to log, on the very next line — announcing a verdict here as well is
+    // how this line came to report a yield in a mode that never consults
+    // Steam and had in fact just taken the controller.
+    EventLog::Write("AUTO: steam state %d (0=none 1=idle 2=inGame)",
+                    static_cast<int>(state));
+    EvaluateControl();
 }
 
 // Hand the controller back. Shared by the auto modes yielding to Steam and by
@@ -495,6 +616,7 @@ void TrayApp::ReleaseControl() {
     KillTimer(m_hwnd, IDT_ACQUIRE);
     KillTimer(m_hwnd, IDT_ACQUIRE_VERDICT);
     KillTimer(m_hwnd, IDT_WAKE_POLL);
+    KillTimer(m_hwnd, IDT_RELEASE_GRACE);
     m_wantControl    = false;
     m_acquireRetries = 0;
     m_lastCycleTick  = 0;
@@ -502,10 +624,13 @@ void TrayApp::ReleaseControl() {
     // One driver notice per attempt, and letting go ends the attempt. Turning
     // Steamless Mode back on is a fresh ask and deserves a fresh answer.
     m_vigemBalloonShown = false;
-    // Whatever game profile was live belongs to a controller we no longer
-    // have. Dropping it now means re-acquiring starts from the default and
-    // re-resolves, rather than resuming a profile for a game long since quit.
-    ActivateProfile({});
+    // Deliberately leaves the selected profile alone. It used to be dropped
+    // here, on the grounds that a profile belongs to a controller we no
+    // longer have — but the selection is now what decides whether we take the
+    // controller in the first place, so clearing it here would erase the
+    // reason we are releasing and call straight back into this function. The
+    // foreground watcher keeps it current whether or not the device is ours,
+    // which is what that reset was standing in for.
     const bool hadControl = m_controller->IsGameModeActive();
     // Good citizen: restore lizard mode and close our HID handles so
     // Steam can claim the controller without contention.
@@ -1046,6 +1171,14 @@ void TrayApp::ShowAlertBalloon(const std::wstring& title, const std::wstring& te
                               BalloonAction action, DWORD infoFlags) {
     m_balloonAction = action;
 
+    // Every balloon the app raises, recorded where it is raised. Notifications
+    // are the one thing this app does that leaves no other trace, so a report
+    // of seeing one twice was otherwise unanswerable — the log could show a
+    // profile loading once and say nothing about how many times Windows drew
+    // the toast. Two lines here means we asked twice; one means Windows drew
+    // it twice, and those want completely different fixes.
+    EventLog::Write("BALLOON: %ls — %ls", title.c_str(), text.c_str());
+
     NOTIFYICONDATAW nid{};
     nid.cbSize      = sizeof(nid);
     nid.hWnd        = m_hwnd;
@@ -1274,9 +1407,12 @@ void TrayApp::LoadSettings() {
         return def;
     };
 
-    // 0 = Manual, 1 = OffWhileSteam, 2 = OffOnlyInGame (old builds stored 0/1).
+    // 0 = Manual, 1 = OffWhileSteam, 2 = OffOnlyInGame, 3 = OffUnlessProfile
+    // (old builds stored 0/1). Anything unrecognised falls back to Manual,
+    // which is the mode that touches nothing on its own.
     const DWORD mode = readDw(L"AutoSteamMode", 0);
-    m_autoMode = mode == 2 ? AutoMode::OffOnlyInGame
+    m_autoMode = mode == 3 ? AutoMode::OffUnlessProfile
+               : mode == 2 ? AutoMode::OffOnlyInGame
                : mode == 1 ? AutoMode::OffWhileSteam
                            : AutoMode::Manual;
     const bool isPlayStation = readDw(L"ControllerPlatform", 0) != 0;
@@ -1468,6 +1604,8 @@ void TrayApp::ShowContextMenu() {
                 IDM_MODE_STEAM, L"Auto - Off while Steam running");
     AppendMenuW(modeMenu, MF_STRING | (m_autoMode == AutoMode::OffOnlyInGame ? MF_CHECKED : MF_UNCHECKED),
                 IDM_MODE_GAME, L"Auto - Off ONLY while in Steam game");
+    AppendMenuW(modeMenu, MF_STRING | (m_autoMode == AutoMode::OffUnlessProfile ? MF_CHECKED : MF_UNCHECKED),
+                IDM_MODE_PROFILE, L"Auto - Off unless a game profile is running");
     AppendMenuW(menu, MF_STRING | MF_POPUP,
                 reinterpret_cast<UINT_PTR>(modeMenu), L"Control Mode");
 

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -18,6 +18,22 @@ enum class AutoMode {
     OffWhileSteam = 1,  // yield whenever steam.exe is running
     OffOnlyInGame = 2,  // yield only while a game is running (needs admin to
                         // wrest the device from a running Steam)
+    // Hold the controller only while a game the user has made a profile for is
+    // in front, and leave it alone the rest of the time.
+    //
+    // The one mode where a profile outranks yielding to Steam: the other two
+    // ask "is Steam busy", and this one asks "did the user say they want us
+    // driving this game". Having made a profile for it is that answer, so a
+    // running Steam is not a reason to refuse — which is the only way a Steam
+    // game launched from the Steam client can ever use one of our profiles.
+    // Needs the same elevated cycle helper OffOnlyInGame does, for the same
+    // reason: taking the device from a live Steam.
+    //
+    // Deliberately keyed on a profile existing rather than on the app being a
+    // game, because "is this a game" is the harder question and this mode is
+    // the place it will eventually be answered — widening the test is all it
+    // takes to become "off unless in a game".
+    OffUnlessProfile = 3,
 };
 
 class TrayApp {
@@ -72,9 +88,20 @@ private:
     void OnForegroundChanged(const ForegroundIdentity& id);
     // The profile id matching an application, or empty when none does.
     std::wstring MatchProfile(const ForegroundIdentity& id) const;
-    // Make `gameId`'s profile the live one (empty selects the default).
-    // Cheap and idempotent when it is already live.
-    void ActivateProfile(const std::wstring& gameId);
+    // Record `gameId`'s profile as the selected one (empty selects the
+    // default), and nothing else. Returns whether the selection changed.
+    //
+    // Deliberately separate from applying it: whether we want the controller
+    // at all now depends on which profile is live, so the selection has to be
+    // on record before EvaluateControl can read it. Keeping the two joined is
+    // what made ReleaseControl and profile switching call each other.
+    bool SelectProfile(const std::wstring& gameId);
+    // The selected profile — a game's if one is selected, else the default.
+    const ControllerProfile& ActiveProfile() const;
+    // Push the selected profile's bindings into ControllerManager. Safe while
+    // the controller is not ours, and called before acquiring rather than
+    // after so the pad comes up already carrying the right bindings.
+    void PushActiveProfile();
     // Re-resolve the foreground now, for the moments where the answer can
     // have changed while nobody was listening — taking the controller back,
     // or closing the window that suppresses switching.
@@ -87,7 +114,19 @@ private:
 
     // Control plumbing, shared by every mode.
     void SetAutoMode(AutoMode mode);
-    bool WantControl(SteamState state) const;
+    // Whether Steam's current state leaves the controller available to us.
+    // A rule rather than a preference: no profile setting may vote itself
+    // into driving the pad alongside Steam Input, which is worse than not
+    // running at all (see ControllerManager's shared-handle note).
+    bool SteamAllowsControl(SteamState state) const;
+    // Do we want the controller right now? One question per mode — the tray
+    // toggle, Steam's state, or whether a game profile is in front — rather
+    // than one answer assembled from settings that override each other.
+    bool WantControlNow() const;
+    // Act on that answer — acquire, or schedule a release. The one place that
+    // turns intent into an acquire or a release, so every caller that can
+    // change the answer routes through here.
+    void EvaluateControl();
     void ApplySteamState(SteamState state);
     void TryAcquireController(uint32_t stateWaitMs = 250);
     void ReleaseControl();
@@ -192,6 +231,7 @@ private:
     static constexpr UINT IDM_OPENLOG       = 1013;
     static constexpr UINT IDM_NOTIFICATIONS = 1014;
     static constexpr UINT IDM_ENABLE_DEVICE = 1015;
+    static constexpr UINT IDM_MODE_PROFILE  = 1016;
     static constexpr UINT WM_TRAY           = WM_APP + 1;
     static constexpr UINT WM_STEAMSTATE     = WM_APP + 2;
     static constexpr UINT WM_ALERT          = WM_APP + 3;
@@ -200,6 +240,7 @@ private:
     static constexpr UINT_PTR IDT_ACQUIRE_VERDICT = 2;
     static constexpr UINT_PTR IDT_WAKE_POLL       = 3;
     static constexpr UINT_PTR IDT_HEARTBEAT       = 4;
+    static constexpr UINT_PTR IDT_RELEASE_GRACE   = 5;
     // Long enough that idling for a month costs a fraction of the log's 512 KB,
     // short enough to bound when the app stopped responding to within a
     // quarter hour. Resolution only has to beat "somewhere in the last 33
@@ -229,6 +270,14 @@ private:
     // waiting through the whole thing costs a handful of log lines, quick
     // enough that the app picks a new driver up on its own.
     static constexpr UINT VIGEM_RETRY_MS = 30000;
+    // Grace before a profile-driven release actually happens. Quick to engage
+    // and slow to disengage, the same asymmetry SteamWatcher uses for Steam
+    // going away — because each release and re-acquire round trip unplugs and
+    // replugs the virtual pad, which a running game sees as the controller
+    // being yanked out. Alt-tabbing to a browser mid-game is common enough
+    // that doing it immediately would read as a bug. Steam turning up is the
+    // one release that skips this; see EvaluateControl.
+    static constexpr UINT RELEASE_GRACE_MS = 5000;
     // Minimum spacing between device cycles. A cycle is asynchronous, so
     // without this the arrivals it generates re-enter the acquire path and
     // fire another one on top of it.


### PR DESCRIPTION
Gives the controller a resting state of "off", coming to life only in games the user has said they want it in. Asked for by a customer who wanted it out of the way at the desktop.

## The mode

The three existing modes all answer *is Steam busy* — Manual defers to the tray toggle, and the two Steam modes yield whenever Steam or a Steam game is running. None can express a controller that stays out of the way and wakes up in a game.

`OffUnlessProfile` answers one different question: is a game the user made a profile for in front? Nothing else, so the outcome is readable off the mode name.

It is also the only mode that does not consult Steam. A Steam game launched from the Steam client always publishes `RunningAppID`, so both existing modes yield for it and a per-game profile could never apply — per-game profiles were effectively dead for most of what a Steam Controller owner plays. Having made a profile is the user saying they want us driving that game rather than Steam Input, and the acquire path already knows how to take the device from a live Steam. With nothing matched the mode wants nothing, so it never contends except over games it was told about.

## What had to change underneath

`OnForegroundChanged` used to return early unless the controller was already ours. It is now the path that decides whether we hold the device at all, so it has to run precisely when we do not. `ActivateProfile` split into `SelectProfile` / `PushActiveProfile` / `EvaluateControl`, because the control decision reads the selection and leaving them joined had `ReleaseControl` and profile switching calling each other.

Releases wait five seconds. Each release and re-acquire round trip unplugs and replugs the virtual pad, which a running game sees as the controller being pulled out, and alt-tabbing mid-game is ordinary. Steam turning up is exempt — the point of yielding is that Steam is about to open the device.

## Profile management

The mode turns profiles from rare into routine, since a profile is now also how you say a game should have the controller. Three things followed:

- **Follow the default.** Every profile used to be a full copy of the controls, forked at creation and never tracking the default again. A profile made only to turn the controller on now resolves to the default instead of copying it, so improving the default reaches every game following it.
- **Delete.** Creating a profile was two clicks and undoing it was impossible — worse now that an unwanted profile also turns the controller on by itself.
- **Reach a profile whose game is gone.** Those were invisible and still working. They are now listed and labelled, never auto-pruned: a deleted shortcut or a disconnected drive looks identical to an uninstall from here.

## Testing

Exercised on hardware against a Steam title launched from the Steam client (Marathon) and an Xbox app title (Forza Horizon 6). Both acquire in ~2s, including wresting the pad from a running Steam via the cycle helper. Verified the grace period holds at ~5.0s on alt-tab, that Steam appearing still releases immediately, and that existing settings are untouched on upgrade.

Two log fixes came out of that testing: `ApplySteamState` was reporting a yield in a mode that never consults Steam, and `ShowAlertBalloon` now records what it raises, since notifications were the one thing the app did that left no trace.

## Known gaps

- Turning on happens at foreground change, so a game already running when we attach may not see the pad if it enumerates only at startup (older DirectInput titles).
- A game whose window opens without stealing focus is not noticed until focused.
- The picker does not distinguish a customized profile from a merely-enabled one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)