### PR TITLE
Document what the installer needs that a clone does not have

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,35 @@ cmake --build build/release --config Release --target SteamlessController
 
 > If you have Visual Studio 2022, replace `"Visual Studio 18 2025"` with `"Visual Studio 17 2022"`.
 
+## Building the installer
+
+The installer is compiled from `resources\InnoInstallerScript.iss` with [Inno Setup](https://jrsoftware.org/isinfo.php). It needs two things a fresh clone does not have.
+
+**Release builds of all three executables it packages.** The command in the previous section builds only the tray app:
+
+```bat
+cmake --build build/release --config Release --target SteamlessController
+cmake --build build/release --config Release --target SteamlessDeviceCycle
+cmake --build build/release --config Release --target ViGEmBusProbe
+```
+
+`SteamlessDeviceCycle` is the elevated helper that restarts the controller's device node. `ViGEmBusProbe` is how Setup checks whether the driver actually installed, and it stays in the install folder afterwards as a diagnostic.
+
+**The ViGEmBus driver installer**, which is not in this repository — it is a 6 MB vendored binary, and `*.exe` is gitignored. Download it from [ViGEmBus releases](https://github.com/nefarius/ViGEmBus/releases/latest) and place it here:
+
+```
+resources\ViGEmBus_1.22.0_x64_x86_arm64.exe
+```
+
+The filename must match `#define ViGEmSetup` at the top of the script. Inno resolves `[Files]` sources when it compiles, so a missing or differently named payload fails the build outright rather than producing an installer that silently ships no driver. If you update the ViGEmBus version, change the `#define` to match the new filename.
+
 ## CMake Targets
 
 | Target | Description |
 |---|---|
 | `SteamlessController` | Main system tray application |
+| `SteamlessDeviceCycle` | Elevated helper that disables and re-enables the controller's device node, run as an on-demand scheduled task. Shipped by the installer. |
+| `ViGEmBusProbe` | Reports whether a ViGEm bus is present by enumerating its interface. Used by Setup to verify the driver installed, and shipped as a diagnostic. |
 | `SteamProbe` | Console diagnostic tool — dumps raw HID report bytes as you interact with the controller. Useful for protocol research. |
 | `RawControllerProbe` | Checks whether `Windows.Gaming.Input.RawGameController` can enumerate the Steam Controller (requires WinRT). |
 


### PR DESCRIPTION
Compiling `resources\InnoInstallerScript.iss` on a fresh checkout fails, and the error names a file with no obvious way to obtain it. Two prerequisites were undocumented.

## The ViGEmBus payload

The script packages `resources\ViGEmBus_1.22.0_x64_x86_arm64.exe`, which is not in the repository — a 6 MB vendored binary caught by the blanket `*.exe` rule in `.gitignore`, under "loose binaries committed by mistake" rather than any rule written for it. That is why it went unnoticed: anyone who has built the installer already had the file sitting in `resources/` from a previous release.

Line 54 has no `skipifsourcedoesntexist`, and Inno resolves `[Files]` sources at compile time, so its absence fails the build rather than quietly producing an installer that ships no driver.

Documented rather than committed. The version is pinned in a single `#define`, and a stale 6 MB binary in history is harder to walk back than a line of prose.

## The two extra executables

`[Files]` also packages `SteamlessDeviceCycle.exe` and `ViGEmBusProbe.exe`, but the Building section only ever told anyone to build `SteamlessController`. Both are now in the build commands, and both are added to the CMake target table, which listed neither.

## Not addressed

The `*.exe` ignore rule is left alone. Narrowing it with a `!resources/ViGEmBus_*.exe` exception would let the payload be committed, which is a real option if reproducible installer builds matter more than repository size — but that is a call worth making deliberately rather than as a side effect of a docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)