### PR TITLE
Fix tray icon restoration after Explorer restart

### DIFF
--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -121,9 +121,9 @@ bool TrayApp::Init(HINSTANCE hInstance) {
     wc.lpszClassName = WNDCLASS_NAME;
     if (!RegisterClassExW(&wc)) return false;
 
-    // Message-only window — invisible, never shown.
+    // Hidden top-level window so it receives broadcast shell notifications including TaskbarCreated when Explorer restarts.
     m_hwnd = CreateWindowExW(0, WNDCLASS_NAME, L"SteamlessController",
-                             0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, hInstance, nullptr);
+                             0, 0, 0, 0, 0, nullptr, nullptr, hInstance, nullptr);
     if (!m_hwnd) return false;
 
     // Register for HID device arrival/removal notifications.


### PR DESCRIPTION
Fixes the tray icon not being restored when Windows Explorer is restarted.

Before:

https://github.com/user-attachments/assets/8e8808b3-a68e-4ed2-a5d0-3133164d69ad

After:

https://github.com/user-attachments/assets/4fc439cf-92be-4f85-9ddd-a45eccd3617e


TrayApp already registers for the TaskbarCreated shell notification and calls AddTrayIcon() when it is received. However, the window used to receive this notification was created as a message-only window using HWND_MESSAGE.

Message-only windows do not receive the broadcast shell notification sent when Explorer recreates the taskbar, so AddTrayIcon() was never called and the application was left running without a tray icon.

This changes the tray window to a hidden top-level window, allowing it to receive TaskbarCreated while remaining invisible.

Result
After restarting Windows Explorer, the Steamless Controller tray icon is automatically registered again without needing to restart the application.