### PR TITLE
Keep the virtual pad type while a game runs, and diagnose two reported bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ src/probe/HapticTester.cpp
 .vs/
 *.user
 *.suo
+
+# Built installers and packaged output
+Output/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ add_executable(SteamlessController WIN32
     src/app/EventLog.cpp
     src/app/ForegroundWatcher.cpp
     src/app/GameLibrary.cpp
+    src/app/GameLiveness.cpp
     src/app/GameProfiles.cpp
     src/app/HandleFinder.cpp
     src/app/LauncherGames.cpp

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.20"
+#define MyAppVersion "1.20.1"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -14,5 +14,5 @@
 // Keep in step with MyAppVersion in resources/InnoInstallerScript.iss.
 #define APP_VERSION_MAJOR 1
 #define APP_VERSION_MINOR 20
-#define APP_VERSION_PATCH 0
-#define APP_VERSION_STR   "1.20"
+#define APP_VERSION_PATCH 1
+#define APP_VERSION_STR   "1.20.1"

--- a/src/app/GameLiveness.cpp
+++ b/src/app/GameLiveness.cpp
@@ -1,0 +1,44 @@
+#include "GameLiveness.h"
+#include "EventLog.h"
+
+void GameLiveness::Hold(const std::wstring& profileId, DWORD pid) {
+    Clear();
+    if (profileId.empty() || pid == 0) return;
+
+    m_profileId = profileId;
+    m_pid       = pid;
+    // SYNCHRONIZE is what makes the cheap check below possible. Asked for on
+    // its own rather than alongside query rights, so a process that would
+    // grant one and not the other still gives us the one we need.
+    m_handle = OpenProcess(SYNCHRONIZE, FALSE, pid);
+
+    EventLog::Write("PROFILE: holding the pad type for %ls (pid %lu, liveness by %s)",
+                    profileId.c_str(), pid, m_handle ? "handle" : "pid");
+}
+
+void GameLiveness::Clear() {
+    if (m_handle) {
+        CloseHandle(m_handle);
+        m_handle = nullptr;
+    }
+    m_profileId.clear();
+    m_pid = 0;
+}
+
+bool GameLiveness::StillRunning() const {
+    if (m_profileId.empty()) return false;
+
+    if (m_handle)
+        return WaitForSingleObject(m_handle, 0) == WAIT_TIMEOUT;
+
+    // No handle. Ask for the least that could possibly be granted and read the
+    // error rather than the result.
+    HANDLE probe = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, m_pid);
+    if (probe) {
+        CloseHandle(probe);
+        return true;
+    }
+    // Denied means it is there and guarded. Anything else — an invalid
+    // parameter, most often — means the id no longer names a process.
+    return GetLastError() == ERROR_ACCESS_DENIED;
+}

--- a/src/app/GameLiveness.cpp
+++ b/src/app/GameLiveness.cpp
@@ -31,12 +31,22 @@ bool GameLiveness::StillRunning() const {
     if (m_handle)
         return WaitForSingleObject(m_handle, 0) == WAIT_TIMEOUT;
 
-    // No handle. Ask for the least that could possibly be granted and read the
-    // error rather than the result.
+    // No handle, so ask for the least that could possibly be granted.
     HANDLE probe = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, m_pid);
     if (probe) {
+        // Opening it proves the process OBJECT exists, which is not the same
+        // as the program running: a pid stays valid for as long as anything
+        // holds a handle to the process, and a launcher or an anti-cheat
+        // service generally does. Measured against Fortnite, an exited game
+        // stayed openable indefinitely and a hold that trusted the open never
+        // released. Ask whether it has exited instead.
+        DWORD      code = 0;
+        const bool read = GetExitCodeProcess(probe, &code) != FALSE;
         CloseHandle(probe);
-        return true;
+        // Unreadable exit code: assume it is running. Being wrong that way
+        // costs the improvement this class exists for; being wrong the other
+        // way rebuilds the pad under a game that is still going.
+        return read ? code == STILL_ACTIVE : true;
     }
     // Denied means it is there and guarded. Anything else — an invalid
     // parameter, most often — means the id no longer names a process.

--- a/src/app/GameLiveness.h
+++ b/src/app/GameLiveness.h
@@ -47,14 +47,17 @@ public:
     // Anti-cheat and elevated games routinely refuse an unelevated process the
     // SYNCHRONIZE right, so a handle is not always available and its absence
     // says nothing about whether the game is running. The fallback re-opens by
-    // pid and reads the failure rather than the success: a pid that no longer
-    // exists fails differently from one we are merely not allowed to touch, and
-    // being denied access to a process is proof it is there.
+    // pid and asks for the exit code, because opening it only proves the
+    // process OBJECT exists: a pid stays valid for as long as anything holds a
+    // handle to the process, which a launcher or an anti-cheat service
+    // generally does. Where it cannot be opened at all, being DENIED access is
+    // itself proof the process is there.
     //
-    // That fallback can be fooled by pid reuse, which needs the game to exit
-    // and the id to be handed to something new between two checks seconds
-    // apart. The cost if it happens is one virtual pad rebuild that should not
-    // have been deferred, at a moment when no game is running to notice.
+    // The fallback can be fooled two ways, both benign. A game exiting with
+    // code 259 reads as STILL_ACTIVE forever, and pid reuse needs the id to be
+    // handed to something new between two checks seconds apart. Either leaves a
+    // hold standing too long, costing the pad rebuild it was deferring — which
+    // is the behaviour this class was added to improve on, not worse than it.
     bool StillRunning() const;
 
 private:

--- a/src/app/GameLiveness.h
+++ b/src/app/GameLiveness.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <Windows.h>
+#include <string>
+
+// Is the game a profile was matched against still running?
+//
+// The foreground is the only push-based signal this app has for "what is the
+// user doing" (see ForegroundWatcher), and it answers a different question
+// from the one profiles are really asking. Alt-tabbing to a browser during a
+// matchmaking queue makes the foreground say "browser" while the honest answer
+// to "what am I playing" is still the game. Asking whether the game's process
+// is alive is what tells the two apart.
+//
+// This exists for exactly one decision: which kind of virtual pad to present.
+// A profile that changes platform tears the pad down and builds it again,
+// which a running game sees as its controller being unplugged, so that must
+// not happen every time somebody alt-tabs. Bindings stay tied to the
+// foreground, because they describe what the user is doing right now — and
+// when the desktop is in front, the desktop's bindings are what is wanted.
+//
+// Liveness is deliberately a poor man's check rather than a process watcher.
+// It is asked a few times a second at most, and it never needs to be right the
+// instant a process dies — nothing is watching the pad in the moment a game
+// exits, so noticing a second or two late costs nothing.
+class GameLiveness {
+public:
+    GameLiveness() = default;
+    ~GameLiveness() { Clear(); }
+    GameLiveness(const GameLiveness&) = delete;
+    GameLiveness& operator=(const GameLiveness&) = delete;
+
+    // Start holding for this profile and process. Replaces whatever was held.
+    void Hold(const std::wstring& profileId, DWORD pid);
+
+    // Stop holding, whatever the reason.
+    void Clear();
+
+    bool               IsHeld()    const { return !m_profileId.empty(); }
+    const std::wstring& ProfileId() const { return m_profileId; }
+    // The process the hold is against, so a caller can notice the same game
+    // running under a new one — a relaunch inside the poll interval would
+    // otherwise leave the hold pinned to a pid that has already gone.
+    DWORD               Pid()       const { return m_pid; }
+
+    // Whether the held process is still alive. False when nothing is held.
+    //
+    // Anti-cheat and elevated games routinely refuse an unelevated process the
+    // SYNCHRONIZE right, so a handle is not always available and its absence
+    // says nothing about whether the game is running. The fallback re-opens by
+    // pid and reads the failure rather than the success: a pid that no longer
+    // exists fails differently from one we are merely not allowed to touch, and
+    // being denied access to a process is proof it is there.
+    //
+    // That fallback can be fooled by pid reuse, which needs the game to exit
+    // and the id to be handed to something new between two checks seconds
+    // apart. The cost if it happens is one virtual pad rebuild that should not
+    // have been deferred, at a moment when no game is running to notice.
+    bool StillRunning() const;
+
+private:
+    std::wstring m_profileId;
+    DWORD        m_pid    = 0;
+    HANDLE       m_handle = nullptr;  // null when the process refused us one
+};

--- a/src/app/ProcessIdentity.cpp
+++ b/src/app/ProcessIdentity.cpp
@@ -74,6 +74,7 @@ ForegroundIdentity ForProcess(DWORD pid) {
 
     id.exePath = ImagePathOf(proc);
     id.aumid   = AumidOf(proc);
+    id.pid     = pid;
     CloseHandle(proc);
     return id;
 }

--- a/src/app/ProcessIdentity.h
+++ b/src/app/ProcessIdentity.h
@@ -13,6 +13,16 @@ struct ForegroundIdentity {
     std::wstring exePath;
     std::wstring aumid;
 
+    // The process this identity was read from, so a caller can go back and
+    // ask whether it is still running. Zero when nothing was resolved.
+    //
+    // Deliberately absent from operator== below: it identifies one run of an
+    // application, while the rest of this identifies the application. The
+    // foreground watcher compares identities to suppress repeat notifications,
+    // and a game relaunched is still the same game to every profile that
+    // matches it.
+    DWORD pid = 0;
+
     bool Empty() const { return exePath.empty() && aumid.empty(); }
     bool operator==(const ForegroundIdentity& o) const {
         return _wcsicmp(exePath.c_str(), o.exePath.c_str()) == 0

--- a/src/app/TrackpadInput.cpp
+++ b/src/app/TrackpadInput.cpp
@@ -1,7 +1,10 @@
 #include "TrackpadInput.h"
+#include "EventLog.h"
 #include "InputInjection.h"
 #include "steam/SteamController.h"
 #include <Windows.h>
+#include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <cstdint>
@@ -229,6 +232,57 @@ void TrackpadInput::UpdateDirections(bool clicked, int16_t x, int16_t y) {
     m_dirs = SectorDirs(m_sector, m_diagonals);
 }
 
+// Reports a single frame that moved further than a finger plausibly can, which
+// is what "I barely touch the pad and it scrolls a whole page" would look like
+// from in here.
+//
+// Movement is integrated from position deltas, so dropped reports are harmless
+// on their own: the displacement still adds up to the same total whether it
+// arrives in ten frames or one. The case that is NOT harmless is a lift and a
+// re-placement that we never saw the touch bit go false across — then the gap
+// between two unrelated points is applied as one enormous swipe.
+//
+// The two are told apart by the time attached to each line rather than by the
+// distance. Milliseconds since the previous touched frame at the report rate
+// means the sensor really did jump that far in one frame, and the touch bit is
+// lying about a finger that left. A long gap means reports went missing during
+// a real movement, which is the benign kind and the reason there is no clamp
+// here yet: a threshold picked without knowing which of these is happening
+// would clip fast flicks on a transport that simply reports less often.
+//
+// The haptic tick path already distrusts jumps like this — see
+// TRACKPAD_TICK_MAX_STEP in ControllerManager — but movement never learned to.
+void TrackpadInput::NoteJump(const uint8_t* buf, size_t n, int dx, int dy) {
+    const double dist = std::hypot(static_cast<double>(dx), static_cast<double>(dy));
+    if (dist < JUMP_REPORT_UNITS) {
+        m_lastFrameAt = std::chrono::steady_clock::now();
+        return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const double sinceFrameMs = m_haveFrameTime
+        ? std::chrono::duration<double, std::milli>(now - m_lastFrameAt).count()
+        : -1.0;
+    m_lastFrameAt   = now;
+    m_haveFrameTime = true;
+
+    // One line every few seconds. A pad that jumps once jumps often, and the
+    // interesting part is the shape of a handful of them, not a flood.
+    if (m_haveLoggedJump
+            && std::chrono::duration<double>(now - m_lastJumpLogAt).count() < JUMP_LOG_GAP_S)
+        return;
+    m_lastJumpLogAt  = now;
+    m_haveLoggedJump = true;
+
+    uint16_t area = 0;
+    if (n >= 30) std::memcpy(&area, buf + (m_isLeftPad ? 22 : 28), 2);
+
+    EventLog::Write("TRACKPAD: %s pad moved %.0f units in one frame "
+                    "(dx=%d dy=%d, %.1fms since the last touched frame, area=%u, mode=%s)",
+                    m_isLeftPad ? "left" : "right", dist, dx, dy,
+                    sinceFrameMs, area, TrackpadModeId(m_mode));
+}
+
 void TrackpadInput::Update(const uint8_t* buf, size_t n, bool pressed) {
     // Only three modes read the pad's position at all. A pad set to None or
     // feeding the DS4 touchpad has nothing for this class to work out, and a
@@ -263,6 +317,7 @@ void TrackpadInput::Update(const uint8_t* buf, size_t n, bool pressed) {
     if (touching && m_touching) {
         const int dxRaw = static_cast<int>(x - m_prevX);
         const int dyRaw = static_cast<int>(y - m_prevY);
+        NoteJump(buf, n, dxRaw, dyRaw);
         if (dxRaw != 0 || dyRaw != 0) {
             if (m_mode == TrackpadMode::MousePointer) {
                 // Pad Y grows upward, screen Y grows downward.

--- a/src/app/TrackpadInput.h
+++ b/src/app/TrackpadInput.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <chrono>
 #include <cstdint>
 #include <cstddef>
 #include "TrackpadConfig.h"
@@ -54,6 +55,11 @@ private:
     // hysteresis margin. Reads m_sector; does not write it.
     int  ResolveSector(double angleDeg) const;
     void UpdateDirections(bool clicked, int16_t x, int16_t y);
+    // Diagnostic only — reports single frames that moved further than a finger
+    // can, and how long since the previous one, which is what separates a
+    // sensor jump from reports going missing. Changes nothing about what is
+    // sent. See the definition.
+    void NoteJump(const uint8_t* buf, size_t n, int dx, int dy);
 
     bool            m_isLeftPad = false;
     TrackpadMode    m_mode      = TrackpadMode::None;
@@ -112,4 +118,20 @@ private:
     // edge-dispatched that is a stream of key down/up pairs rather than a
     // cosmetic flicker.
     static constexpr double SECTOR_HYSTERESIS_DEG = 8.0;
+
+    // ---- Movement jump reporting (diagnostic) ----
+
+    // Far enough in one frame that no finger did it. The pad's axes saturate
+    // at +/-32767, so this is roughly a fifth of the way across in a single
+    // report — well past a fast flick at any report rate either transport
+    // uses, and nowhere near the pad-width gap a missed lift produces.
+    static constexpr double JUMP_REPORT_UNITS = 6000.0;
+    // A pad that jumps once jumps often. A handful of examples says everything
+    // a flood would, so the rest are dropped.
+    static constexpr double JUMP_LOG_GAP_S = 3.0;
+
+    std::chrono::steady_clock::time_point m_lastFrameAt{};
+    std::chrono::steady_clock::time_point m_lastJumpLogAt{};
+    bool m_haveFrameTime  = false;
+    bool m_haveLoggedJump = false;
 };

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -385,6 +385,12 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             // so the answer can change while it runs, and coming back to the
             // game is the case it is here for.
             if (!WantControlNow()) ReleaseControl();
+        } else if (wp == IDT_GAME_LIVENESS) {
+            // The game holding the pad type has gone, so the type can follow
+            // the selected profile again — and the rebuild that costs is free
+            // now in a way it never is while the game is up.
+            if (!m_platformHold.StillRunning())
+                ReleasePlatformHold(L"the game exited");
         } else if (wp == IDT_STEAM_RECONCILE) {
             // The watcher announces an edge exactly once, through one
             // PostMessage. If that message is lost the app keeps a stale view
@@ -584,6 +590,58 @@ const ControllerProfile& TrayApp::ActiveProfile() const {
     return m_defaultProfile;
 }
 
+ControllerProfile TrayApp::EffectiveProfile() const {
+    ControllerProfile profile = ActiveProfile();
+
+    // A held pad type outranks the selected profile's, and only the pad type.
+    // Everything else — every binding, every pad mode — is the foreground's to
+    // decide, so alt-tabbing to the desktop still gets the desktop's controls.
+    if (m_platformHold.IsHeld()) {
+        auto it = m_gameProfiles.find(m_platformHold.ProfileId());
+        if (it != m_gameProfiles.end()) {
+            // A profile that follows the default has no platform of its own,
+            // exactly as ActiveProfile resolves it.
+            profile.platform = it->second.useDefaultMappings
+                             ? m_defaultProfile.platform
+                             : it->second.platform;
+        }
+    }
+    return profile;
+}
+
+void TrayApp::UpdatePlatformHold(const ForegroundIdentity& id) {
+    // Only a matched game holds anything. Landing on the desktop deliberately
+    // leaves the previous hold alone — that is the whole point, and what makes
+    // alt-tabbing free.
+    if (m_activeGameId.empty() || id.pid == 0) return;
+    // Same game AND the same run of it. The pid is part of the test because a
+    // game closed and reopened inside the poll interval is the same profile
+    // wearing a new process, and a hold left pinned to the old one would be
+    // dropped by the next liveness check for a game that is plainly running.
+    if (m_platformHold.IsHeld()
+            && m_platformHold.ProfileId() == m_activeGameId
+            && m_platformHold.Pid() == id.pid)
+        return;
+
+    // A different game takes over, and its pad type applies immediately. That
+    // rebuild is not one to defer: the user has just switched to the game that
+    // wants it.
+    m_platformHold.Hold(m_activeGameId, id.pid);
+    SetTimer(m_hwnd, IDT_GAME_LIVENESS, LIVENESS_POLL_MS, nullptr);
+}
+
+void TrayApp::ReleasePlatformHold(const wchar_t* why) {
+    if (!m_platformHold.IsHeld()) return;
+    EventLog::Write("PROFILE: released the pad type held for %ls (%ls)",
+                    m_platformHold.ProfileId().c_str(), why);
+    m_platformHold.Clear();
+    KillTimer(m_hwnd, IDT_GAME_LIVENESS);
+    // Re-apply so the pad type goes back to following the selected profile.
+    // Safe here in a way it never is mid-session: whatever needed the old type
+    // is gone, so nothing is watching the pad it rebuilds.
+    if (WantControlNow()) PushActiveProfile();
+}
+
 bool TrayApp::SelectProfile(const std::wstring& gameId) {
     if (gameId == m_activeGameId) return false;
 
@@ -600,7 +658,9 @@ bool TrayApp::SelectProfile(const std::wstring& gameId) {
 
 void TrayApp::PushActiveProfile() {
     const ControllerProfile& profile = ActiveProfile();
-    m_controller->SetProfile(profile);
+    // The blend, not the selection: bindings from whatever is in front, pad
+    // type from whatever game is still running. See EffectiveProfile.
+    m_controller->SetProfile(EffectiveProfile());
 
     if (m_activeGameId.empty()) return;  // returning to the default is not news
 
@@ -640,6 +700,11 @@ void TrayApp::OnForegroundChanged(const ForegroundIdentity& id) {
     if (m_remapWindow.IsOpen()) return;
 
     if (!SelectProfile(MatchProfile(id))) return;
+    // Before pushing: a game coming to the front claims the pad type, and
+    // keeps it until it exits. Landing on the desktop claims nothing and
+    // leaves the previous claim standing, which is what stops an alt-tab
+    // rebuilding the pad under a game that is still running.
+    UpdatePlatformHold(id);
     // Only push a profile we are actually going to run. Applying one changes
     // the pad in place, but a profile whose platform differs rebuilds the
     // virtual controller outright — so pushing the default on the way out of
@@ -653,7 +718,13 @@ void TrayApp::OnForegroundChanged(const ForegroundIdentity& id) {
 
 void TrayApp::RefreshActiveProfile() {
     if (m_remapWindow.IsOpen()) return;
-    SelectProfile(MatchProfile(ForegroundWatcher::Current()));
+    const ForegroundIdentity id = ForegroundWatcher::Current();
+    SelectProfile(MatchProfile(id));
+    // Catching up on the hold too. This runs at the moments nobody was
+    // listening — taking the controller back, closing the window that
+    // suppresses switching — and a game that has been in front the whole time
+    // should be holding the pad type by the end of it.
+    UpdatePlatformHold(id);
     if (WantControlNow()) PushActiveProfile();  // see OnForegroundChanged
     EvaluateControl();
 }
@@ -1377,6 +1448,11 @@ void TrayApp::OpenRemapWindow() {
             m_gameProfiles.erase(gameId);
             GameProfiles::Save(m_gameProfiles);
             EventLog::Write("PROFILE: deleted %ls", gameId.c_str());
+            // A deleted profile stops deciding anything, including the pad
+            // type it was holding — which would otherwise outlive it for as
+            // long as its game kept running, with nothing left to explain it.
+            if (m_platformHold.IsHeld() && m_platformHold.ProfileId() == gameId)
+                ReleasePlatformHold(L"its profile was deleted");
             // No control decision here, for the same reason applying makes
             // none: the window is open and may have a row listening for a
             // button, and dropping the controller under it would end that

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -658,9 +658,33 @@ bool TrayApp::SelectProfile(const std::wstring& gameId) {
 
 void TrayApp::PushActiveProfile() {
     const ControllerProfile& profile = ActiveProfile();
+    const ControllerProfile  applied = EffectiveProfile();
     // The blend, not the selection: bindings from whatever is in front, pad
     // type from whatever game is still running. See EffectiveProfile.
-    m_controller->SetProfile(EffectiveProfile());
+    m_controller->SetProfile(applied);
+
+    // What actually reached the controller, which is not the same question as
+    // which profile matched — a profile set to follow the default matches, is
+    // reported as switched to, and then supplies none of its own bindings.
+    // That is the shape of "my custom bindings do nothing", and without this
+    // line a log shows a profile loading correctly while the user watches it
+    // have no effect.
+    //
+    // Only on a change: this is called on every foreground switch, and one
+    // line per alt-tab would bury everything else.
+    const bool following = !m_activeGameId.empty()
+                        && ActiveProfile().useDefaultMappings;
+    std::wstring applying = (m_activeGameId.empty() ? std::wstring(L"the default profile")
+                                                    : m_activeGameId)
+                          + (applied.platform == ControllerPlatform::PlayStation
+                                 ? L" [PlayStation]" : L" [Xbox]")
+                          + (following ? L" (following the default — its own bindings are"
+                                         L" not being used)"
+                                       : L"");
+    if (applying != m_lastAppliedDescription) {
+        m_lastAppliedDescription = applying;
+        EventLog::Write("PROFILE: applied %ls", applying.c_str());
+    }
 
     if (m_activeGameId.empty()) return;  // returning to the default is not news
 

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -723,12 +723,22 @@ void TrayApp::OnForegroundChanged(const ForegroundIdentity& id) {
     // would apply their changes to the wrong game.
     if (m_remapWindow.IsOpen()) return;
 
-    if (!SelectProfile(MatchProfile(id))) return;
-    // Before pushing: a game coming to the front claims the pad type, and
-    // keeps it until it exits. Landing on the desktop claims nothing and
-    // leaves the previous claim standing, which is what stops an alt-tab
-    // rebuilding the pad under a game that is still running.
+    const bool selectionChanged = SelectProfile(MatchProfile(id));
+
+    // A game coming to the front claims the pad type and keeps it until it
+    // exits. Landing on the desktop claims nothing and leaves the previous
+    // claim standing, which is what stops an alt-tab rebuilding the pad under
+    // a game that is still running.
+    //
+    // Asked before the early return below, because the hold follows a process
+    // while the selection follows a profile, and the two do not change
+    // together. A loader that hands off to the game it launched is the same
+    // profile wearing a new pid: the selection does not change, so the return
+    // fires, and a hold left on the old process is dropped the moment that
+    // process exits — rebuilding the pad under a game that has only just
+    // started.
     UpdatePlatformHold(id);
+    if (!selectionChanged) return;
     // Only push a profile we are actually going to run. Applying one changes
     // the pad in place, but a profile whose platform differs rebuilds the
     // virtual controller outright — so pushing the default on the way out of

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -266,6 +266,9 @@ private:
     // The game the "profile loaded" balloon last named, so alt-tabbing in and
     // out of one game does not raise it over and over.
     std::wstring                       m_toastedGameId;
+    // What was last reported as applied, so the line is written on a change
+    // rather than on every foreground switch.
+    std::wstring                       m_lastAppliedDescription;
 
     // Which game's profile decides the kind of virtual pad, for as long as
     // that game is running. Set when a profile matches the foreground and kept

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include "DeviceRestart.h"
 #include "ForegroundWatcher.h"
+#include "GameLiveness.h"
 #include "GameProfiles.h"
 #include "RemapWindow.h"
 #include "SteamAppLocator.h"
@@ -107,6 +108,19 @@ private:
     bool SelectProfile(const std::wstring& gameId);
     // The selected profile — a game's if one is selected, else the default.
     const ControllerProfile& ActiveProfile() const;
+    // What to actually apply: the selected profile, but wearing the pad type
+    // of whichever game is still running. Returned by value because it is a
+    // blend of two profiles rather than either of them, and every caller wants
+    // the blend — ActiveProfile stays the answer to "which profile did the
+    // user's foreground select", which is a different question.
+    ControllerProfile EffectiveProfile() const;
+    // Start or stop holding the pad type for whatever the foreground matched,
+    // and keep the liveness timer running only while there is something to
+    // watch.
+    void UpdatePlatformHold(const ForegroundIdentity& id);
+    // Drop the hold and re-apply, so the pad type follows the profile again.
+    // The one moment the rebuild is free: the game that needed it has gone.
+    void ReleasePlatformHold(const wchar_t* why);
     // Push the selected profile's bindings into ControllerManager. Safe while
     // the controller is not ours, and called before acquiring rather than
     // after so the pad comes up already carrying the right bindings.
@@ -253,6 +267,23 @@ private:
     // out of one game does not raise it over and over.
     std::wstring                       m_toastedGameId;
 
+    // Which game's profile decides the kind of virtual pad, for as long as
+    // that game is running. Set when a profile matches the foreground and kept
+    // across alt-tabs, because a platform change rebuilds the pad and a
+    // running game reads that as its controller being unplugged.
+    //
+    // Only the platform is held. Bindings still follow the foreground, so
+    // alt-tabbing to the desktop still hands the desktop its own controls —
+    // which matters, since the default profile is the one that makes the pads
+    // a mouse and a scroll wheel.
+    //
+    // Nothing here helps AutoMode::OffUnlessProfile, whose whole design is to
+    // release the physical controller the moment a profiled game is not in
+    // front. That destroys the virtual pad outright, so there is no pad left
+    // to hold a type for. Left that way on purpose: it is the most restrictive
+    // mode and being restrictive is what it is for.
+    GameLiveness                       m_platformHold;
+
     static constexpr UINT IDM_TOGGLE        = 1001;
     static constexpr UINT IDM_EXIT          = 1002;
     // 1003 and 1005 were the retired "Enable Trackpad Mouse" and "Use Left
@@ -281,6 +312,7 @@ private:
     static constexpr UINT_PTR IDT_RELEASE_GRACE   = 5;
     static constexpr UINT_PTR IDT_STEAM_RECONCILE = 6;
     static constexpr UINT_PTR IDT_CYCLE_WATCHDOG  = 7;
+    static constexpr UINT_PTR IDT_GAME_LIVENESS   = 8;
     // Long enough that idling for a month costs a fraction of the log's 512 KB,
     // short enough to bound when the app stopped responding to within a
     // quarter hour. Resolution only has to beat "somewhere in the last 33
@@ -321,6 +353,11 @@ private:
     // that doing it immediately would read as a bug. Steam turning up is the
     // one release that skips this; see EvaluateControl.
     static constexpr UINT RELEASE_GRACE_MS = 5000;
+    // How often to ask whether the game holding the pad type is still there.
+    // Deliberately lazy: nothing is watching the pad in the moment a game
+    // exits, so noticing a second or two late costs nothing, and the check is
+    // one wait on a handle we already hold.
+    static constexpr UINT LIVENESS_POLL_MS = 2000;
     // Minimum spacing between device cycles. A cycle is asynchronous, so
     // without this the arrivals it generates re-enter the acquire path and
     // fire another one on top of it.


### PR DESCRIPTION
Closes #92.

Alt-tabbing out of a game switched its profile back to the default immediately, and a profile that changes platform tears the virtual pad down and builds it again. That is the Windows connect/disconnect sound in the report — twice per round trip — and worse than the noise, a game polling XInput sees its controller unplugged while it is still running.

## The delay that was supposed to cover this never ran

`RELEASE_GRACE_MS` guards handing the *physical controller* back. In Manual mode `WantControlNow()` keeps answering yes when the foreground changes, so the profile was pushed with nothing in the way. Exposing that delay as a setting — the original plan — would have made a number configurable that this path never consults, and the reporter would have come back saying it still switches instantly.

A delay would not have been enough anyway. They alt-tab during matchmaking queues and to use a browser, which is minutes; any grace period expires and the switch happens regardless.

## The unit being switched was wrong

A platform is only meaningful to a game. Desktop bindings are keyboard and mouse going out through `SendInput`, which never touches the virtual pad, so nothing on the desktop cares what type it is. Bindings are the opposite — they describe what the user is doing right now, and when the desktop is in front the desktop's bindings are the ones wanted.

So the two are split:

- **Bindings follow the foreground**, exactly as before.
- **The pad type follows whichever profiled game is running** — claimed when a game comes to the front, kept across alt-tabs, released when the process exits.

The one unavoidable rebuild moves to game exit, when nothing is watching, instead of happening twice per alt-tab. No setting: it takes nothing away from anyone, since desktop controls still arrive on alt-tab exactly as they do today.

Deliberately does nothing for `AutoMode::OffUnlessProfile`, which releases the controller the moment a profiled game is not in front and destroys the pad outright, leaving no pad to hold a type for. That mode exists to be restrictive.

## Liveness

A wait on a process handle, falling back to `GetExitCodeProcess` by pid where anti-cheat refuses `SYNCHRONIZE`, and treating a denied open as proof the process is there. Polled every two seconds rather than watched — nothing is looking at the pad in the moment a game exits.

Both paths are verified on hardware, and forcing the fallback found two bugs that would otherwise only ever have misbehaved on other people's machines:

- **It never released.** Asking whether a pid can be opened is not asking whether the process is running: a pid stays valid for as long as anything holds a handle to the process object, and a launcher or an anti-cheat service generally does. Fortnite exited, the pid stayed openable, and the hold stood forever.
- **The hold was gated on the profile selection changing**, so a loader handing off to the game it launched — the same profile wearing a new pid — left the hold on the old process, which released the moment that process exited.

Tested across Marathon (Steam id) and Fortnite (exe-path id), both liveness paths, both platform directions: held across alt-tabs, released within the poll interval of the game closing.

## Diagnostics for two other reports

**#95, scrolling far too fast.** The wheel-lines diagnostic added in 1.20 ruled out its own hypothesis — the reporter was on 10 lines per notch, which really was scrolling them 3.3x fast, but setting it back to 3 changed nothing. Report id and length, screen size and wheel setting now all match a machine where scrolling is fine; the transport does not.

Movement integrates position deltas, so dropped reports are harmless on their own — the displacement adds up the same however many frames it arrives in. What is not harmless is a finger lifting and landing elsewhere without the touch bit ever being seen false, because then the gap between two unrelated points is applied as one enormous swipe. A wireless transport dropping the odd report is how those frames go missing.

So single frames that move further than a finger can are now logged, with the milliseconds since the previous touched frame attached — which is what separates a sensor jump from reports going missing. No clamp yet, deliberately: a threshold picked before knowing which is happening would clip fast flicks on a transport that simply reports less often. The haptic tick path has distrusted jumps like this for a while; movement never learned to, and this is the evidence for what it should learn.

**Bindings appearing not to apply.** A profile set to follow the default matches, is reported as switched to, and then supplies none of its own bindings — and nothing in a log could show that. The applied profile is now logged when it changes, saying both the platform and whether the profile is following the default. Also worth knowing on its own: a newly created game profile has "use my default mappings" ticked, so it can match perfectly and apply nothing.

## Known gap

A game that never produces a foreground event is never matched. Clicking onto a freshly loaded game can leave the default applied until the next alt-tab. Pre-existing rather than introduced here, and the likely cause is `ForegroundIdentity::operator==` comparing exe path only, so a loader handing off to a game sharing that path reads as "same app" and the callback is suppressed. Left for its own change, since fixing it means the watcher's change test and profile matching stop asking the same question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
