### PR TITLE
Release 1.21

### DIFF
--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.20.1"
+#define MyAppVersion "1.21"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -13,6 +13,6 @@
 //
 // Keep in step with MyAppVersion in resources/InnoInstallerScript.iss.
 #define APP_VERSION_MAJOR 1
-#define APP_VERSION_MINOR 20
-#define APP_VERSION_PATCH 1
-#define APP_VERSION_STR   "1.20.1"
+#define APP_VERSION_MINOR 21
+#define APP_VERSION_PATCH 0
+#define APP_VERSION_STR   "1.21"


### PR DESCRIPTION
Version bump only — `APP_VERSION_*` in `resources/resource.h` and `MyAppVersion` in the installer script, which the header asks to be kept in step.

## What 1.21 carries over 1.20

**Alt-tabbing no longer replugs the virtual controller** (#92). A profile whose platform differs from the default used to tear the pad down and rebuild it every time focus left the game and again when it came back — the Windows connect/disconnect sound in that report, and something a running game sees as its controller being unplugged. The pad type now follows whichever profiled game is running rather than whatever is in front, so the one unavoidable rebuild happens when the game exits and nothing is watching.

**Diagnostics for two open reports.** Trackpad frames that move further than a finger can are logged with the time since the previous touched frame (#95), which separates a sensor jump from reports going missing. The applied profile is logged when it changes, including whether a profile is following the default and therefore supplying none of its own bindings — a state nothing in a log could previously show.

The trackpad Directional Pad and Single Button modes are also new since the last public release, but shipped under the 1.20 tag rather than in this bump.

## 1.20.1

Existed only so private test builds identified themselves in their own log header. Nothing shipped under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
