### PR TITLE
Scroll sensitivity: normalise against the machine, and make it tunable (#95)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,7 +23,7 @@
       "name": "release",
       "configurePreset": "release",
       "configuration": "Release",
-      "targets": ["SteamlessController"]
+      "targets": ["SteamlessController", "SteamlessDeviceCycle", "ViGEmBusProbe"]
     },
     {
       "name": "debug",

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.21.3"
+#define MyAppVersion "1.21.4"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.21.4"
+#define MyAppVersion "1.22"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.21.1"
+#define MyAppVersion "1.21.2"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.21.2"
+#define MyAppVersion "1.21.3"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -3,7 +3,7 @@
 ; Non-commercial use only
 
 #define MyAppName "SteamlessController"
-#define MyAppVersion "1.21"
+#define MyAppVersion "1.21.1"
 #define ViGEmSetup "ViGEmBus_1.22.0_x64_x86_arm64.exe"
 #define MyAppPublisher "Dylan Deverill"
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"

--- a/resources/InnoInstallerScript.iss
+++ b/resources/InnoInstallerScript.iss
@@ -9,6 +9,36 @@
 #define MyAppURL "https://github.com/ddeverill/SteamlessController"
 #define MyAppExeName "SteamlessController.exe"
 
+; Where the packaged binaries come from, spelled once so the version check
+; below and the [Files] entries cannot drift apart.
+#define BuildDir "build\release\Release\"
+
+; Refuse to build an installer around a stale executable.
+;
+; The trap this exists for: the Visual Studio generator is multi-config, so
+; CMAKE_BUILD_TYPE does nothing and "cmake --build build/release" quietly
+; produces DEBUG. The Release directory packaged here keeps whatever was in it
+; from the last correct build, which can be weeks old. Setup then stamps
+; MyAppVersion on the metadata and installs an executable that reports its own
+; older version — an installer that says one thing while Add/Remove Programs,
+; the log banner and the features present all say another.
+;
+; That shipped once, to the #95 reporter, and cost a round trip to work out.
+; Nothing about it was visible: setup succeeded, the version in Add/Remove
+; Programs was right, and only the app's own log gave it away.
+;
+; Build it properly with:  cmake --build --preset release
+; (the preset carries "configuration": "Release"; the bare path form does not)
+; Note the "../": [Files] resolves against SourceDir, but the preprocessor
+; resolves against this script's own directory.
+#define ExeVersion GetStringFileInfo("../" + BuildDir + MyAppExeName, "FileVersion")
+#if ExeVersion != MyAppVersion
+  ; #error takes its line literally and evaluates nothing, so the versions
+  ; are printed by #pragma message, which does.
+  #pragma message "Packaged " + MyAppExeName + " is version " + ExeVersion + " but this script builds " + MyAppVersion
+  #error The packaged executable is stale - see the message above. Run: cmake --build --preset release
+#endif
+
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
@@ -46,11 +76,11 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "build\release\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "build\release\Release\SteamlessDeviceCycle.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#BuildDir}{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#BuildDir}SteamlessDeviceCycle.exe"; DestDir: "{app}"; Flags: ignoreversion
 ; Setup's driver check, and the thing to ask a user to run when a controller
 ; never reaches a game. Installed rather than temporary for the second reason.
-Source: "build\release\Release\ViGEmBusProbe.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#BuildDir}ViGEmBusProbe.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "resources\{#ViGEmSetup}"; DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Icons]

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -14,5 +14,5 @@
 // Keep in step with MyAppVersion in resources/InnoInstallerScript.iss.
 #define APP_VERSION_MAJOR 1
 #define APP_VERSION_MINOR 21
-#define APP_VERSION_PATCH 1
-#define APP_VERSION_STR   "1.21.1"
+#define APP_VERSION_PATCH 2
+#define APP_VERSION_STR   "1.21.2"

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -14,5 +14,5 @@
 // Keep in step with MyAppVersion in resources/InnoInstallerScript.iss.
 #define APP_VERSION_MAJOR 1
 #define APP_VERSION_MINOR 21
-#define APP_VERSION_PATCH 0
-#define APP_VERSION_STR   "1.21"
+#define APP_VERSION_PATCH 1
+#define APP_VERSION_STR   "1.21.1"

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -13,6 +13,6 @@
 //
 // Keep in step with MyAppVersion in resources/InnoInstallerScript.iss.
 #define APP_VERSION_MAJOR 1
-#define APP_VERSION_MINOR 21
-#define APP_VERSION_PATCH 4
-#define APP_VERSION_STR   "1.21.4"
+#define APP_VERSION_MINOR 22
+#define APP_VERSION_PATCH 0
+#define APP_VERSION_STR   "1.22"

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -14,5 +14,5 @@
 // Keep in step with MyAppVersion in resources/InnoInstallerScript.iss.
 #define APP_VERSION_MAJOR 1
 #define APP_VERSION_MINOR 21
-#define APP_VERSION_PATCH 3
-#define APP_VERSION_STR   "1.21.3"
+#define APP_VERSION_PATCH 4
+#define APP_VERSION_STR   "1.21.4"

--- a/resources/resource.h
+++ b/resources/resource.h
@@ -14,5 +14,5 @@
 // Keep in step with MyAppVersion in resources/InnoInstallerScript.iss.
 #define APP_VERSION_MAJOR 1
 #define APP_VERSION_MINOR 21
-#define APP_VERSION_PATCH 2
-#define APP_VERSION_STR   "1.21.2"
+#define APP_VERSION_PATCH 3
+#define APP_VERSION_STR   "1.21.3"

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -479,6 +479,8 @@ void ControllerManager::ApplyPadSettings(Slot& slot) {
     slot.rightPad.SetMode(m_profile.rightPad.mode);
     slot.leftPad.SetScrollDirection(m_profile.leftPad.scrollDir);
     slot.rightPad.SetScrollDirection(m_profile.rightPad.scrollDir);
+    slot.leftPad.SetScrollSpeed(m_profile.leftPad.scrollSpeed);
+    slot.rightPad.SetScrollSpeed(m_profile.rightPad.scrollSpeed);
     slot.leftPad.SetDiagonals(m_profile.leftPad.diagonals);
     slot.rightPad.SetDiagonals(m_profile.rightPad.diagonals);
     // The virtual controller reads pad modes straight off the profile it is

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -475,12 +475,24 @@ void ControllerManager::ReleaseDevices() {
 
 // One pad, in the terms a bug report is written in.
 //
-// Scroll carries more than the others because a scroll-feels-wrong report has
-// two independent multipliers behind it, and neither alone explains the feel:
-// the user's own speed setting, and the machine's lines-per-notch, which
-// Windows applies to every wheel event after we send it. The net figure is
-// what the pad actually does relative to the calibrated feel, and it is the
-// number worth comparing between two machines.
+// Scroll reports its speed as a fraction of the calibrated feel, because that
+// is exactly what it is. The correction and the machine's lines-per-notch
+// cancel:
+//
+//   wheel units  W = D x SCROLL_SENSITIVITY x correction x speed/100
+//   lines        L = W / WHEEL_DELTA x linesPerNotch
+//   correction     = kCalibratedWheelLines / linesPerNotch
+//   so           L = D x SCROLL_SENSITIVITY x kCalibratedWheelLines x speed/100
+//                    / WHEEL_DELTA
+//
+// linesPerNotch is gone, which is the whole point of correcting for it — the
+// same swipe covers the same ground everywhere, and the speed setting alone
+// says how far. This line used to also report speed x correction as a "net"
+// figure, which is the multiplier on the wheel units we send and NOT what the
+// scroll feels like; it read as 8% for a pad that was in fact scrolling at 25%
+// of calibrated. The correction is still worth printing, since it explains why
+// two machines showing the same speed send different wheel numbers, but it is
+// not a second thing to multiply by.
 static std::string DescribePad(const TrackpadSettings& pad) {
     switch (pad.mode) {
     case TrackpadMode::MousePointer:   return "pointer";
@@ -495,16 +507,16 @@ static std::string DescribePad(const TrackpadSettings& pad) {
         const char* dir = pad.scrollDir == ScrollDirection::Reversed ? "reversed"
                                                                     : "natural";
         char buf[160];
-        // The correction is 1.0 on a machine left at the Windows default, where
-        // repeating it and the net figure would say the same thing three times.
+        // Nothing to explain on a machine left at the Windows default, where
+        // the correction is 1.0 and printing it only invites the question of
+        // what to multiply by.
         if (std::fabs(correction - 1.0f) < 0.005f)
-            snprintf(buf, sizeof(buf), "scroll (%s, speed %u%%)", dir, pad.scrollSpeed);
+            snprintf(buf, sizeof(buf), "scroll (%s, speed %u%% of calibrated)",
+                     dir, pad.scrollSpeed);
         else
             snprintf(buf, sizeof(buf),
-                     "scroll (%s, speed %u%%, wheel correction x%.2f, net %.0f%% of "
-                     "calibrated)",
-                     dir, pad.scrollSpeed, static_cast<double>(correction),
-                     static_cast<double>(pad.scrollSpeed) * correction);
+                     "scroll (%s, speed %u%% of calibrated, wheel correction x%.2f)",
+                     dir, pad.scrollSpeed, static_cast<double>(correction));
         return buf;
     }
     default: return "none";

--- a/src/app/ControllerManager.cpp
+++ b/src/app/ControllerManager.cpp
@@ -472,6 +472,62 @@ void ControllerManager::ReleaseDevices() {
     NotifyStateChanged();
 }
 
+
+// One pad, in the terms a bug report is written in.
+//
+// Scroll carries more than the others because a scroll-feels-wrong report has
+// two independent multipliers behind it, and neither alone explains the feel:
+// the user's own speed setting, and the machine's lines-per-notch, which
+// Windows applies to every wheel event after we send it. The net figure is
+// what the pad actually does relative to the calibrated feel, and it is the
+// number worth comparing between two machines.
+static std::string DescribePad(const TrackpadSettings& pad) {
+    switch (pad.mode) {
+    case TrackpadMode::MousePointer:   return "pointer";
+    case TrackpadMode::DS4Touchpad:    return "ds4 touchpad";
+    case TrackpadMode::SingleButton:   return "single button";
+    case TrackpadMode::DirectionalPad:
+        return std::string("dpad (")
+             + (pad.diagonals == DiagonalMode::FourWay ? "4-way" : "8-way") + ")";
+    case TrackpadMode::ScrollWheel: {
+        const float correction =
+            InputInjection::WheelCorrection(InputInjection::WheelLinesPerNotch());
+        const char* dir = pad.scrollDir == ScrollDirection::Reversed ? "reversed"
+                                                                    : "natural";
+        char buf[160];
+        // The correction is 1.0 on a machine left at the Windows default, where
+        // repeating it and the net figure would say the same thing three times.
+        if (std::fabs(correction - 1.0f) < 0.005f)
+            snprintf(buf, sizeof(buf), "scroll (%s, speed %u%%)", dir, pad.scrollSpeed);
+        else
+            snprintf(buf, sizeof(buf),
+                     "scroll (%s, speed %u%%, wheel correction x%.2f, net %.0f%% of "
+                     "calibrated)",
+                     dir, pad.scrollSpeed, static_cast<double>(correction),
+                     static_cast<double>(pad.scrollSpeed) * correction);
+        return buf;
+    }
+    default: return "none";
+    }
+}
+
+void ControllerManager::LogPadSettings() {
+    std::string line = "PADS: left=" + DescribePad(m_profile.leftPad)
+                     + " right="     + DescribePad(m_profile.rightPad);
+
+    // The failure this exists to make visible: settings changed with game mode
+    // off do nothing at all, and until now nothing said so. Two #95 sessions
+    // were spent that way — one where the pad was never claimed, one where it
+    // was configured after the claim.
+    if (!IsGameModeActive())
+        line += " — game mode is off, so these are not driving anything yet";
+
+    if (line == m_lastPadDescription) return;
+    m_lastPadDescription = line;
+    // %s rather than the line as a format: it contains per-cent signs.
+    EventLog::Write("%s", line.c_str());
+}
+
 void ControllerManager::ApplyPadSettings(Slot& slot) {
     slot.leftPad.SetPad(true);
     slot.rightPad.SetPad(false);
@@ -513,6 +569,9 @@ void ControllerManager::SetProfile(const ControllerProfile& profile) {
     // live inside the per-slot TrackpadInput objects, so those are pushed.
     for (auto& slot : m_slots)
         ApplyPadSettings(*slot);
+
+    // After the push, so what is logged is what the pads are now set to.
+    LogPadSettings();
 }
 
 // Sends the key or mouse event a binding stands for. Gamepad actions reach the
@@ -932,19 +991,30 @@ ControllerManager::EnableGameModeSlot(Slot& slot, bool& padUnavailableOut, bool 
     // Takeover is the moment users report the trackpad arriving dead, and what
     // decides whether injection can land is whatever window happens to be in
     // front right then — so record it here rather than reconstructing it later.
-    if (m_profile.leftPad.ClaimedForDesktop() || m_profile.rightPad.ClaimedForDesktop())
-        InputInjection::LogEnvironment("game mode taken");
+    //
+    // Unconditional. It used to fire only when a pad was already claimed for
+    // the desktop, which quietly withheld it from the two reports most likely
+    // to need it: a pad configured after enabling, and a trackpad that does
+    // nothing because no pad is claimed at all. The second is worth a line
+    // saying so, not silence.
+    InputInjection::LogEnvironment("game mode taken");
     slot.gameModeActive = true;
     slot.leftPad.Reset();
     slot.rightPad.Reset();
     ReleaseHeldPaddleInputs(slot);
     ApplyPadSettings(slot);
+    // After gameModeActive, so the line does not claim the pads are inert.
+    LogPadSettings();
     StartReadLoop(slot);
     return GameModeOutcome::Enabled;
 }
 
 void ControllerManager::DisableGameModeSlot(Slot& slot) {
     if (!slot.gameModeActive) return;
+    // Forget what was last logged, so the next enable states the pad setup
+    // again rather than deduplicating against a previous session's line. Each
+    // enable in the log should be readable without scrolling back past it.
+    m_lastPadDescription.clear();
     EventLog::Write("GAMEMODE: disabled %ls", slot.path.c_str());
     StopReadLoop(slot);
     if (slot.sc->IsOpen())

--- a/src/app/ControllerManager.h
+++ b/src/app/ControllerManager.h
@@ -150,6 +150,16 @@ private:
     // its virtual controller. Shared by SetProfile and slot creation.
     void ApplyPadSettings(Slot& slot);
 
+    // Records what the pads are set to, once per change.
+    //
+    // The enable-time environment line cannot answer this. It fires from
+    // EnableGameMode and describes the moment control was taken, so a pad
+    // configured afterwards — the ordinary order, since the settings window is
+    // how you configure one — is never described at all. Two rounds of #95
+    // diagnostics went by on logs that could not say whether the pad under
+    // test was even in scroll mode.
+    void LogPadSettings();
+
     StateChangedFn                     m_onStateChanged;
     AlertFn                            m_alertFn;
     std::vector<std::unique_ptr<Slot>> m_slots;
@@ -167,6 +177,9 @@ private:
     Pounce                             m_pounce;
     bool                               m_lastPadDriverMissing = false;
     std::wstring                       m_lastBusReport;
+    // The last line LogPadSettings wrote, so a setting that did not change
+    // does not write one. SetProfile runs on every foreground switch.
+    std::string                        m_lastPadDescription;
     ControllerProfile                  m_profile;
 
     std::atomic<bool>                            m_capturing{false};

--- a/src/app/GameProfiles.cpp
+++ b/src/app/GameProfiles.cpp
@@ -51,6 +51,8 @@ void ReadPad(HKEY key, const wchar_t* prefix, TrackpadSettings& pad) {
     pad.mode      = TrackpadModeFromDword(ReadDw(key, name(L"Mode").c_str(), 0));
     pad.click     = binding(L"Click", BackButtonAction::None);
     pad.scrollDir = ScrollDirectionFromDword(ReadDw(key, name(L"ScrollDir").c_str(), 0));
+    // Zero means absent, which ScrollSpeedFromDword reads as the default.
+    pad.scrollSpeed = ScrollSpeedFromDword(ReadDw(key, name(L"ScrollSpeed").c_str(), 0));
     // Absent from every profile written before the directional modes existed.
     // The defaults match TrackpadSettings' own, so those profiles read back as
     // an unconfigured directional pad rather than a broken one.
@@ -68,6 +70,7 @@ void WritePad(HKEY key, const wchar_t* prefix, const TrackpadSettings& pad) {
     WriteDw(key, name(L"Mode").c_str(),      static_cast<DWORD>(pad.mode));
     WriteDw(key, name(L"Click").c_str(),     pad.click.Pack());
     WriteDw(key, name(L"ScrollDir").c_str(), static_cast<DWORD>(pad.scrollDir));
+    WriteDw(key, name(L"ScrollSpeed").c_str(), pad.scrollSpeed);
     WriteDw(key, name(L"Touch").c_str(),     pad.touch.Pack());
     WriteDw(key, name(L"Up").c_str(),        pad.up.Pack());
     WriteDw(key, name(L"Down").c_str(),      pad.down.Pack());

--- a/src/app/InputInjection.cpp
+++ b/src/app/InputInjection.cpp
@@ -286,18 +286,73 @@ namespace InputInjection {
 // choose. Scroll is injected as wheel events — 120 units to a notch — and
 // Windows multiplies each notch by this before anything moves, so identical
 // injection scrolls wildly different amounts on two machines. The default is
-// 3 lines; WHEEL_PAGESCROLL means a notch is a whole page, which turns the
-// gentlest flick of a pad into a page jump and is not something a sensitivity
-// setting can tune away, the granularity being the problem rather than the
-// scale. Worth a line in the log, since a scroll-feels-wrong report otherwise
-// gives no way to tell this apart from a bug in our own arithmetic.
+// 3 lines; WHEEL_PAGESCROLL means a notch is a whole page.
+//
+// Zero when the system will not say, which callers read as "we do not know"
+// rather than as a number of lines.
+static UINT RawWheelLines() {
+    UINT lines = 0;
+    if (!SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &lines, 0)) return 0;
+    return lines;
+}
+
+// Worth a line in the log, since a scroll-feels-wrong report otherwise gives
+// no way to tell this apart from a bug in our own arithmetic. Carries the
+// correction as well as the setting: the two together say both what the
+// machine does and what we did about it, which is the difference between a
+// report that reproduces and one that does not.
 static std::wstring DescribeWheelLines() {
-    UINT lines = 3;
-    if (!SystemParametersInfoW(SPI_GETWHEELSCROLLLINES, 0, &lines, 0))
-        return L"unknown";
-    if (lines == WHEEL_PAGESCROLL) return L"one page per notch (!)";
+    const UINT lines = RawWheelLines();
+    if (lines == 0) return L"unknown";
+
+    const std::wstring correction =
+        L", scroll scaled to "
+        + std::to_wstring(static_cast<int>(
+              WheelCorrection(WheelLinesPerNotch()) * 100.0f + 0.5f))
+        + L"%";
+
+    if (lines == WHEEL_PAGESCROLL)
+        return L"one page per notch (!)" + correction;
     return std::to_wstring(lines) + L" lines per notch"
-         + (lines == 3 ? L"" : L" (not the default 3)");
+         + (lines == 3 ? L"" : L" (not the default 3)") + correction;
+}
+
+// A page, counted in lines, for the one setting that is not measured in them.
+// Nothing reports how tall the scrolling thing under the cursor is, so this is
+// an estimate of a screenful of text and it is only ever approximately right.
+// It is still much closer than treating a page as three lines, which is what
+// not handling this case at all amounts to.
+//
+// Note that scaling cannot fully rescue WHEEL_PAGESCROLL: with a whole page to
+// a notch the granularity is the problem rather than the scale, and the
+// smallest movement that survives rounding is still a big one.
+constexpr float kPageScrollLines = 20.0f;
+
+// Re-read at most this often. The value changes only when somebody drags a
+// slider in Settings.
+constexpr uint64_t kWheelCacheMs = 1000;
+
+float WheelLinesPerNotch() {
+    // Asked once per scroll frame — at report rate while a thumb is moving —
+    // so it is cached rather than plumbed through WM_SETTINGCHANGE: nothing on
+    // this path owns a window, and a second of staleness in a comfort setting
+    // is not something a hand can feel.
+    static std::atomic<uint64_t> nextReadAt{0};  // 0: never read, so read now
+    static std::atomic<float>    cached{kCalibratedWheelLines};
+
+    const uint64_t now = GetTickCount64();
+    if (now >= nextReadAt.load(std::memory_order_relaxed)) {
+        nextReadAt.store(now + kWheelCacheMs, std::memory_order_relaxed);
+        const UINT lines = RawWheelLines();
+        // An unreadable setting is assumed to be the default, which makes the
+        // correction 1.0 and leaves the scale exactly where it was.
+        const float effective = lines == 0               ? kCalibratedWheelLines
+                              : lines == WHEEL_PAGESCROLL ? kPageScrollLines
+                                                          : static_cast<float>(lines);
+        cached.store(effective, std::memory_order_relaxed);
+        return effective;
+    }
+    return cached.load(std::memory_order_relaxed);
 }
 
 void LogEnvironment(const char* reason) {

--- a/src/app/InputInjection.h
+++ b/src/app/InputInjection.h
@@ -45,6 +45,39 @@ void SetAlertCallback(AlertFn fn);
 // the same as the event arriving; see above.
 bool Send(const INPUT& input, const char* what);
 
+// Lines per wheel notch that the injected scroll scale is calibrated against,
+// which is the Windows default. A machine set to anything else has every wheel
+// event we send multiplied by a different number on arrival, so identical
+// injection scrolls a different distance there; dividing the scale by
+// WheelLinesPerNotch() below is what makes one swipe of a trackpad cover the
+// same ground everywhere. See TrackpadInput::UpdateScroll.
+//
+// Anchoring at the default rather than at 1 is deliberate: the correction is
+// then exactly 1.0 on a machine nobody has touched, so normalising changes
+// nothing for the great majority of installs and only moves the ones that were
+// already out of step.
+inline constexpr float kCalibratedWheelLines = 3.0f;
+
+// The factor the scroll scale is multiplied by on a machine reporting `lines`
+// lines per notch. Pure and separated from the setting it is normally fed so
+// the property that matters can be checked rather than argued about: it is
+// exactly 1.0 at the default, which is what makes normalising safe to turn on
+// for every install at once.
+//
+// Zero guards a divide against a system that reports nothing usable. It does
+// not happen today, and a scroll that silently becomes infinite is not the way
+// to discover that it started.
+inline constexpr float WheelCorrection(float lines) {
+    return lines > 0.0f ? kCalibratedWheelLines / lines : 1.0f;
+}
+
+// The system's "roll the mouse wheel to scroll N lines" setting, resolved to a
+// number that scale can divide by. WHEEL_PAGESCROLL becomes an estimated
+// page's worth of lines, and a setting that cannot be read at all becomes
+// kCalibratedWheelLines, which corrects by exactly 1.0 and so leaves the scale
+// where it was. Cached internally; cheap enough to call once per report.
+float WheelLinesPerNotch();
+
 // Everything that decides whether injection can land: the foreground window's
 // process and integrity level, ours, any cursor clip, and whether the cursor
 // can be read at all. Logged when game mode is taken, and whenever injection

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <thread>
 #include <cstring>
+#include <cstdlib>
 
 RemapWindow* RemapWindow::s_instance = nullptr;
 
@@ -126,6 +127,12 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 .mode-select{background:#101925;border:1px solid rgba(255,255,255,.12);border-radius:6px;color:#fff;font-size:13px;font-family:'Barlow',system-ui,sans-serif;padding:7px 10px;font-weight:600;cursor:pointer;flex:none;min-width:215px;}
 .mode-select:hover{border-color:#66c0f4;}
 .mode-select:focus{outline:none;border-color:#66c0f4;}
+.speed-wrap{display:flex;align-items:center;gap:10px;flex:none;min-width:215px;}
+.speed-slider{-webkit-appearance:none;appearance:none;flex:1;height:4px;border-radius:2px;background:rgba(255,255,255,.16);outline:none;cursor:pointer;}
+.speed-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;width:15px;height:15px;border-radius:50%;background:#66c0f4;border:none;cursor:pointer;}
+.speed-slider:hover::-webkit-slider-thumb{background:#8fd3ff;}
+.speed-slider:focus{outline:none;}
+.speed-val{font-family:'JetBrains Mono',monospace;font-size:12px;color:#8f98a0;font-weight:600;min-width:44px;text-align:right;}
 .picker{margin-top:12px;background:#101925;border:1px solid rgba(102,192,244,.2);border-radius:8px;padding:12px 13px;}
 .picker-label{font-family:'JetBrains Mono',monospace;font-size:10.5px;letter-spacing:1px;color:#5c6b78;font-weight:600;}
 .picker-rows{display:flex;flex-direction:column;gap:7px;margin-top:10px;}
@@ -242,6 +249,16 @@ R"HTML(
         <select id="dir-LPAD" class="mode-select"></select>
       </div>
     </div>
+    <div class="row mode-row" id="speed-row-LPAD">
+      <div class="row-top">
+        <span class="pos-label">Scroll Speed</span>
+        <div class="connector"></div>
+        <div class="speed-wrap">
+          <input type="range" id="speed-LPAD" class="speed-slider">
+          <span class="speed-val" id="speed-val-LPAD">100%</span>
+        </div>
+      </div>
+    </div>
     <div class="row mode-row" id="diag-row-LPAD">
       <div class="row-top">
         <span class="pos-label">Diagonals</span>
@@ -271,6 +288,16 @@ R"HTML(
         <span class="pos-label">Scroll Direction</span>
         <div class="connector"></div>
         <select id="dir-RPAD" class="mode-select"></select>
+      </div>
+    </div>
+    <div class="row mode-row" id="speed-row-RPAD">
+      <div class="row-top">
+        <span class="pos-label">Scroll Speed</span>
+        <div class="connector"></div>
+        <div class="speed-wrap">
+          <input type="range" id="speed-RPAD" class="speed-slider">
+          <span class="speed-val" id="speed-val-RPAD">100%</span>
+        </div>
       </div>
     </div>
     <div class="row mode-row" id="diag-row-RPAD">
@@ -351,6 +378,11 @@ var DEFAULTS = {L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none',LPAD:'none',RP
 var DEFAULT_MODES = {LPAD:'scroll',RPAD:'pointer'};
 var DEFAULT_DIRS  = {LPAD:'natural',RPAD:'natural'};
 var DEFAULT_DIAGS = {LPAD:'eight',RPAD:'eight'};
+// Percent of the calibrated scroll scale. Keep the bounds in step with
+// kScrollSpeedMin/Max in TrackpadConfig.h — the C++ side clamps to them, so a
+// slider allowed to travel further would just snap back on apply.
+var DEFAULT_SPEEDS = {LPAD:100,RPAD:100};
+var SPEED_MIN = 25, SPEED_MAX = 400, SPEED_STEP = 5;
 var DEFAULT_PLATFORM = 'xbox';
 
 // ---- State ----
@@ -363,6 +395,9 @@ var dirs = {LPAD:'natural',RPAD:'natural'};
 // Whether a directional pad's diagonals press two directions or round to one.
 // Kept for every pad for the same reason as the scroll direction.
 var diags = {LPAD:'eight',RPAD:'eight'};
+// Scroll speed per pad, kept for every pad for the same reason as the two
+// above: switching modes back and forth must not lose the choice.
+var speeds = {LPAD:100,RPAD:100};
 var platform = 'xbox';
 // This game follows the default profile's controls instead of carrying its
 // own. Only ever true for a game — the default has nothing to follow.
@@ -458,7 +493,7 @@ var runningOpen = false;
 // Each profile is a flat object: one entry per bindable row id, plus
 // "<pad>mode" for each trackpad's movement mode. Flat because the JSON
 // reader on the C++ side matches "key":"value" pairs without nesting.
-var PROFILES = {'':{platform:'xbox',L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none',LPAD:'none',RPAD:'leftMouse',LPADmode:'scroll',RPADmode:'pointer',LPADdir:'natural',RPADdir:'natural',LPADdiag:'eight',RPADdiag:'eight',LPADtouch:'none',RPADtouch:'none',LPADup:'Up',LPADdown:'Down',LPADleft:'Left',LPADright:'Right',RPADup:'Up',RPADdown:'Down',RPADleft:'Left',RPADright:'Right'}};
+var PROFILES = {'':{platform:'xbox',L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none',LPAD:'none',RPAD:'leftMouse',LPADmode:'scroll',RPADmode:'pointer',LPADdir:'natural',RPADdir:'natural',LPADspeed:'100',RPADspeed:'100',LPADdiag:'eight',RPADdiag:'eight',LPADtouch:'none',RPADtouch:'none',LPADup:'Up',LPADdown:'Down',LPADleft:'Left',LPADright:'Right',RPADup:'Up',RPADdown:'Down',RPADleft:'Left',RPADright:'Right'}};
 var currentGame = '';
 var comboOpen = false;
 var comboQuery = '';
@@ -652,6 +687,23 @@ function setMode(padId,modeId){
 function setDir(padId,dirId){
   dirs[padId]=dirId;
 }
+// The one place a scroll speed is bounded, so a value arriving from storage
+// and one arriving from the slider cannot disagree. Anything unparseable or
+// zero is "unset", which is what the registry writes for a profile saved
+// before this setting existed — see ScrollSpeedFromDword.
+function clampSpeed(padId,value){
+  var v=parseInt(value,10);
+  if(isNaN(v)||v===0) return DEFAULT_SPEEDS[padId];
+  return Math.min(SPEED_MAX,Math.max(SPEED_MIN,v));
+}
+// Live while dragging, so the readout tracks the thumb. Stored as a number;
+// currentProfile stringifies it on the way out, matching every other value on
+// the wire.
+function setSpeed(padId,value){
+  speeds[padId]=clampSpeed(padId,value);
+  var out=document.getElementById('speed-val-'+padId);
+  if(out) out.textContent=speeds[padId]+'%';
+}
 function setDiag(padId,diagId){
   diags[padId]=diagId;
 }
@@ -660,11 +712,12 @@ function resetDefaults(){
   platform=DEFAULT_PLATFORM;
   bindings={};
   ROWS.forEach(function(r){bindings[r.id]=DEFAULTS[r.id];});
-  modes={}; dirs={}; diags={};
+  modes={}; dirs={}; diags={}; speeds={};
   PADS.forEach(function(p){
     modes[p]=DEFAULT_MODES[p];
     dirs[p]=DEFAULT_DIRS[p];
     diags[p]=DEFAULT_DIAGS[p];
+    speeds[p]=DEFAULT_SPEEDS[p];
   });
   flash=null;
   clearTimeout(flashTimer);
@@ -687,6 +740,7 @@ function currentProfile(){
     p[x+'mode']=modes[x];
     p[x+'dir']=dirs[x];
     p[x+'diag']=diags[x];
+    p[x+'speed']=String(speeds[x]);
   });
   return p;
 }
@@ -708,11 +762,14 @@ function loadProfileInto(p){
   ROWS.forEach(function(r){
     bindings[r.id]=p.hasOwnProperty(r.id)?p[r.id]:DEFAULTS[r.id];
   });
-  modes={}; dirs={}; diags={};
+  modes={}; dirs={}; diags={}; speeds={};
   PADS.forEach(function(x){
     modes[x]=p.hasOwnProperty(x+'mode')?p[x+'mode']:DEFAULT_MODES[x];
     dirs[x] =p.hasOwnProperty(x+'dir') ?p[x+'dir'] :DEFAULT_DIRS[x];
     diags[x]=p.hasOwnProperty(x+'diag')?p[x+'diag']:DEFAULT_DIAGS[x];
+    // clampSpeed turns a missing key into the default, so this needs no
+    // hasOwnProperty guard of its own.
+    speeds[x]=clampSpeed(x,p[x+'speed']);
   });
   savedProfile=currentProfile();
 }
@@ -995,6 +1052,14 @@ function renderModeSelects(){
     fillSelect('mode-'+padId,opts,modes[padId]);
     fillSelect('dir-'+padId,DIR_OPTIONS,dirs[padId]);
     fillSelect('diag-'+padId,DIAG_OPTIONS,diags[padId]);
+    var speedSel=document.getElementById('speed-'+padId);
+    if(speedSel){
+      speedSel.min=SPEED_MIN; speedSel.max=SPEED_MAX; speedSel.step=SPEED_STEP;
+      speedSel.value=speeds[padId];
+    }
+    // Goes through setSpeed so the readout beside the slider is written by the
+    // one function that owns it, rather than by two that can drift apart.
+    setSpeed(padId,speeds[padId]);
   });
   renderPadRows();
 }
@@ -1005,6 +1070,8 @@ function renderPadRows(){
     var shown=PAD_ROWS_BY_MODE[mode]||[];
     var dirRow=document.getElementById('dir-row-'+padId);
     if(dirRow) dirRow.style.display=(mode==='scroll')?'':'none';
+    var speedRow=document.getElementById('speed-row-'+padId);
+    if(speedRow) speedRow.style.display=(mode==='scroll')?'':'none';
     var diagRow=document.getElementById('diag-row-'+padId);
     if(diagRow) diagRow.style.display=(mode==='dpad')?'':'none';
     // Only a directional pad splits its surface, so only it needs explaining.
@@ -1117,6 +1184,10 @@ PADS.forEach(function(padId){
   if(dirSel) dirSel.addEventListener('change',function(e){setDir(padId,e.target.value);});
   var diagSel=document.getElementById('diag-'+padId);
   if(diagSel) diagSel.addEventListener('change',function(e){setDiag(padId,e.target.value);});
+  var speedSel=document.getElementById('speed-'+padId);
+  // 'input' rather than 'change': the readout has to follow the thumb while it
+  // is being dragged, not only when it is let go.
+  if(speedSel) speedSel.addEventListener('input',function(e){setSpeed(padId,e.target.value);});
 });
 
 // mousedown as well as click: the document-level handler below closes the
@@ -1992,6 +2063,10 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
             s.click     = BackButtonBinding::FromId(JsonStr(msg, id));
             s.mode      = TrackpadModeFromId(JsonStr(msg, id + "mode"));
             s.scrollDir = ScrollDirectionFromId(JsonStr(msg, id + "dir"));
+            // strtoul yields 0 for anything unparseable, which is the same
+            // "unset" the registry uses and lands on the default.
+            s.scrollSpeed = ScrollSpeedFromDword(static_cast<uint32_t>(
+                std::strtoul(JsonStr(msg, id + "speed").c_str(), nullptr, 10)));
             s.diagonals = DiagonalModeFromId(JsonStr(msg, id + "diag"));
             s.touch     = BackButtonBinding::FromId(JsonStr(msg, id + "touch"));
             s.up        = BackButtonBinding::FromId(JsonStr(msg, id + "up"));
@@ -2083,6 +2158,7 @@ std::wstring RemapWindow::ProfileJson(const ControllerProfile& p) {
         return L"\"" + k + L"\":\"" + wid(s.click) + L"\","
                L"\"" + k + L"mode\":\"" + narrow(TrackpadModeId(s.mode)) + L"\","
                L"\"" + k + L"dir\":\"" + narrow(ScrollDirectionId(s.scrollDir)) + L"\","
+               L"\"" + k + L"speed\":\"" + std::to_wstring(s.scrollSpeed) + L"\","
                L"\"" + k + L"diag\":\"" + narrow(DiagonalModeId(s.diagonals)) + L"\","
                L"\"" + k + L"touch\":\"" + wid(s.touch) + L"\","
                L"\"" + k + L"up\":\"" + wid(s.up) + L"\","

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -255,7 +255,7 @@ R"HTML(
         <div class="connector"></div>
         <div class="speed-wrap">
           <input type="range" id="speed-LPAD" class="speed-slider">
-          <span class="speed-val" id="speed-val-LPAD">100%</span>
+          <span class="speed-val" id="speed-val-LPAD">1x</span>
         </div>
       </div>
     </div>
@@ -296,7 +296,7 @@ R"HTML(
         <div class="connector"></div>
         <div class="speed-wrap">
           <input type="range" id="speed-RPAD" class="speed-slider">
-          <span class="speed-val" id="speed-val-RPAD">100%</span>
+          <span class="speed-val" id="speed-val-RPAD">1x</span>
         </div>
       </div>
     </div>
@@ -378,11 +378,25 @@ var DEFAULTS = {L4:'leftMouse',L5:'none',R4:'leftMouse',R5:'none',LPAD:'none',RP
 var DEFAULT_MODES = {LPAD:'scroll',RPAD:'pointer'};
 var DEFAULT_DIRS  = {LPAD:'natural',RPAD:'natural'};
 var DEFAULT_DIAGS = {LPAD:'eight',RPAD:'eight'};
-// Percent of the calibrated scroll scale. Keep the bounds in step with
-// kScrollSpeedMin/Max in TrackpadConfig.h — the C++ side clamps to them, so a
-// slider allowed to travel further would just snap back on apply.
+// Percent of the calibrated scroll scale. Keep in step with
+// kScrollSpeedDefault in TrackpadConfig.h.
 var DEFAULT_SPEEDS = {LPAD:100,RPAD:100};
-var SPEED_MIN = 25, SPEED_MAX = 400, SPEED_STEP = 5;
+// The stops the scroll speed slider offers, as percentages of the calibrated
+// feel. Stored and sent as those percentages, so the C++ side keeps taking any
+// value in kScrollSpeedMin..Max and nothing about persistence changes — these
+// are where the slider is willing to stop, not what the setting can hold.
+//
+// Discrete rather than continuous for two reasons. The spacing is roughly a
+// constant ratio (about 1.4x a step), which a linear slider cannot be: over
+// 10..400 linear, three quarters of the track sits above 1x where nobody has
+// asked to go, and the region people actually use is squeezed into the first
+// quarter. And a named stop can be said out loud — "set it to 0.5x" ends a
+// support round trip that "set it to 47%" starts another one of.
+//
+// 100 is here because it is the default, and 25 because that is where the #95
+// reporter settled; a list that rounded either of them away would move a
+// setting somebody had already chosen.
+var SPEED_STOPS = [10,15,25,35,50,75,100,150,200,300,400];
 var DEFAULT_PLATFORM = 'xbox';
 
 // ---- State ----
@@ -691,18 +705,32 @@ function setDir(padId,dirId){
 // and one arriving from the slider cannot disagree. Anything unparseable or
 // zero is "unset", which is what the registry writes for a profile saved
 // before this setting existed — see ScrollSpeedFromDword.
+//
+// Snaps to the nearest stop, so the slider position and the readout always
+// describe the same number. A value between stops can still be stored — an
+// older build wrote continuous ones, and C++ accepts anything in range — it
+// simply shows as the stop nearest it, and only becomes that value if the user
+// applies.
 function clampSpeed(padId,value){
   var v=parseInt(value,10);
   if(isNaN(v)||v===0) return DEFAULT_SPEEDS[padId];
-  return Math.min(SPEED_MAX,Math.max(SPEED_MIN,v));
+  var best=SPEED_STOPS[0];
+  for(var i=0;i<SPEED_STOPS.length;i++){
+    if(Math.abs(SPEED_STOPS[i]-v)<Math.abs(best-v)) best=SPEED_STOPS[i];
+  }
+  return best;
 }
-// Live while dragging, so the readout tracks the thumb. Stored as a number;
+// How a stop is written for a person: a multiplier, because that is what it is
+// and because "0.5x" survives being read aloud into a bug report.
+function speedLabel(value){ return String(value/100)+'x'; }
+// Live while dragging, so the readout tracks the thumb. Takes a percentage, not
+// a slider position — the listener converts. Stored as a number;
 // currentProfile stringifies it on the way out, matching every other value on
 // the wire.
 function setSpeed(padId,value){
   speeds[padId]=clampSpeed(padId,value);
   var out=document.getElementById('speed-val-'+padId);
-  if(out) out.textContent=speeds[padId]+'%';
+  if(out) out.textContent=speedLabel(speeds[padId]);
 }
 function setDiag(padId,diagId){
   diags[padId]=diagId;
@@ -1054,8 +1082,10 @@ function renderModeSelects(){
     fillSelect('diag-'+padId,DIAG_OPTIONS,diags[padId]);
     var speedSel=document.getElementById('speed-'+padId);
     if(speedSel){
-      speedSel.min=SPEED_MIN; speedSel.max=SPEED_MAX; speedSel.step=SPEED_STEP;
-      speedSel.value=speeds[padId];
+      // The slider travels over stop INDEXES, which is what makes the spacing
+      // ratio-even rather than linear in the percentage.
+      speedSel.min=0; speedSel.max=SPEED_STOPS.length-1; speedSel.step=1;
+      speedSel.value=SPEED_STOPS.indexOf(clampSpeed(padId,speeds[padId]));
     }
     // Goes through setSpeed so the readout beside the slider is written by the
     // one function that owns it, rather than by two that can drift apart.
@@ -1187,7 +1217,10 @@ PADS.forEach(function(padId){
   var speedSel=document.getElementById('speed-'+padId);
   // 'input' rather than 'change': the readout has to follow the thumb while it
   // is being dragged, not only when it is let go.
-  if(speedSel) speedSel.addEventListener('input',function(e){setSpeed(padId,e.target.value);});
+  // The slider's value is a stop index; setSpeed wants the percentage.
+  if(speedSel) speedSel.addEventListener('input',function(e){
+    setSpeed(padId,SPEED_STOPS[parseInt(e.target.value,10)]);
+  });
 });
 
 // mousedown as well as click: the document-level handler below closes the

--- a/src/app/RemapWindow.cpp
+++ b/src/app/RemapWindow.cpp
@@ -133,6 +133,12 @@ button{font-family:'Barlow',system-ui,sans-serif;cursor:pointer;border:none;back
 .speed-slider:hover::-webkit-slider-thumb{background:#8fd3ff;}
 .speed-slider:focus{outline:none;}
 .speed-val{font-family:'JetBrains Mono',monospace;font-size:12px;color:#8f98a0;font-weight:600;min-width:44px;text-align:right;}
+.offbar{display:none;margin:0 0 14px;padding:11px 13px;border-radius:8px;background:rgba(214,146,42,.13);border:1px solid rgba(214,146,42,.42);align-items:center;gap:12px;}
+.offbar.on{display:flex;}
+.offbar-text{flex:1;font-size:12.5px;color:#e8c07a;line-height:1.45;}
+.offbar-text b{color:#ffd699;font-weight:700;}
+.offbar-btn{padding:7px 14px;border-radius:3px;border:1px solid #4c7a1d;background:linear-gradient(to bottom,#94c63d,#5d8a1f);color:#13260a;font-weight:700;font-size:12.5px;white-space:nowrap;}
+.offbar-btn:hover{opacity:.9;}
 .picker{margin-top:12px;background:#101925;border:1px solid rgba(102,192,244,.2);border-radius:8px;padding:12px 13px;}
 .picker-label{font-family:'JetBrains Mono',monospace;font-size:10.5px;letter-spacing:1px;color:#5c6b78;font-weight:600;}
 .picker-rows{display:flex;flex-direction:column;gap:7px;margin-top:10px;}
@@ -195,6 +201,10 @@ R"HTML(
   <div>
     <h2>Customize Controls</h2>
     <p class="instr">Click <b>Rebind</b> on any button, then press any gamepad button on your controller &#8212; or any key on your keyboard, or your mouse's middle or thumb buttons. The new binding shows up here instantly. Pick <b>Off</b> to stop a button doing anything at all.</p>
+  </div>
+  <div class="offbar" id="offbar">
+    <div class="offbar-text" id="offbar-text"></div>
+    <button class="offbar-btn" id="offbar-btn">Enable</button>
   </div>
   <div class="group">
     <div class="group-label">APPLY TO</div>
@@ -619,6 +629,10 @@ if(window.chrome&&window.chrome.webview){
       renderComboLabel();
       renderModeSelects();
       renderAll();
+    } else if(msg.type==='controlState'){
+      controlOn     = msg.enabled==='1';
+      controlManual = msg.manual==='1';
+      renderOffbar();
     } else if(msg.type==='games'){
       // Finding every installed app takes a second or more, so it lands after
       // the window is already up — and possibly after the user has started
@@ -1052,6 +1066,39 @@ function setPlatform(value){
 // The checkbox belongs to a game, never to the default profile, and while it
 // is ticked everything below it describes controls this game is not using —
 // so the settings are dimmed and inert, and "reset this profile" with them.
+// Whether the controller is actually being driven, and whether this window is
+// allowed to change that. Both arrive from the app; assume off until told, so
+// a page that somehow never hears warns rather than staying quiet about it.
+var controlOn = false, controlManual = true;
+// Every setting in this window does nothing while Steamless mode is off. The
+// event log has said so for a while, which turned out to be no use at all —
+// people are looking at this window, not at a log, and three separate test
+// sessions were spent changing settings that were never connected to anything.
+function renderOffbar(){
+  var bar=document.getElementById('offbar');
+  if(!bar) return;
+  bar.className = controlOn ? 'offbar' : 'offbar on';
+  if(controlOn) return;
+  var text=document.getElementById('offbar-text');
+  var btn=document.getElementById('offbar-btn');
+  // Deliberately says nothing about whether the settings are saved. An earlier
+  // draft ended "they are saved either way", which reads as though the page
+  // saves on its own — and it does not; Apply does. A banner about one thing
+  // being off is the wrong place to imply something else is automatic.
+  if(controlManual){
+    text.innerHTML='<b>Steamless mode is off.</b> Nothing on this page is '+
+                   'driving your controller yet - the trackpads, paddles '+
+                   'and buttons below take effect once it is on.';
+    if(btn) btn.style.display='';
+  }else{
+    // Not ours to switch on: an auto mode owns the decision, and a button here
+    // would either lie or fight it a moment later.
+    text.innerHTML='<b>Steamless mode is off right now.</b> Control Mode is set '+
+                   'to one of the automatic options, so it turns on by itself '+
+                   'when the conditions are met. Settings below take effect then.';
+    if(btn) btn.style.display='none';
+  }
+}
 function renderInherit(){
   var group=document.getElementById('inherit-group');
   if(group) group.style.display=(currentGame==='')?'none':'';
@@ -1196,6 +1243,13 @@ document.getElementById('btn-min').onclick=function(){postMsg({type:'minimize'})
 document.getElementById('btn-close').onclick=function(){guard(function(){postMsg({type:'close'});});};
 document.getElementById('btn-reset').onclick=resetDefaults;
 document.getElementById('btn-apply').onclick=applyBindings;
+var offBtn=document.getElementById('offbar-btn');
+if(offBtn) offBtn.onclick=function(){
+  // No optimistic hiding: enabling can fail (no ViGEm, a device another
+  // process will not release) and a banner that vanished on click would claim
+  // a success nothing verified. The app pushes the real state when it knows.
+  postMsg({type:'requestEnable'});
+};
 
 document.getElementById('use-default').addEventListener('change',function(e){
   useDefault=e.target.checked;
@@ -2150,11 +2204,30 @@ void RemapWindow::OnWebMessage(const std::wstring& raw) {
             break;
         }
 
+    } else if (type == "requestEnable") {
+        // Only ever offered in manual mode, but checked here too: the mode can
+        // change while the window is up, and a stale button must not reach
+        // past the tray's own rule about who decides.
+        if (m_controlManual && m_onRequestEnable) m_onRequestEnable();
+
     } else if (type == "browseExe") {
         BrowseForExe();
     }
 }
 
+
+// Pushed whenever the tray's view of the world changes, and again when the
+// page comes up — the window is usually opened while the state is already
+// settled, so waiting for the next change would leave the banner wrong until
+// something unrelated happened.
+void RemapWindow::SetControlState(bool enabled, bool manual) {
+    m_controlEnabled = enabled;
+    m_controlManual  = manual;
+    if (!m_webview) return;
+    PostToWebView(std::wstring(L"{\"type\":\"controlState\",\"enabled\":\"")
+                  + (enabled ? L"1" : L"0")
+                  + L"\",\"manual\":\"" + (manual ? L"1" : L"0") + L"\"}");
+}
 void RemapWindow::PostToWebView(const std::wstring& jsonStr) {
     if (m_webview) m_webview->PostWebMessageAsString(jsonStr.c_str());
 }
@@ -2261,6 +2334,11 @@ void RemapWindow::SendInitState() {
         L",\"games\":[" + GamesJson() + L"]"
         L",\"profiles\":{" + ProfilesJson() + L"}}";
     PostToWebView(json);
+
+    // Sent separately rather than folded into the init message: the same state
+    // arrives later whenever it changes, so the page needs one handler for it
+    // either way, and having two ways to learn it is how they drift.
+    SetControlState(m_controlEnabled, m_controlManual);
 }
 
 // Token-based picker ids so the raw game id — possibly non-ASCII, sometimes

--- a/src/app/RemapWindow.h
+++ b/src/app/RemapWindow.h
@@ -62,6 +62,26 @@ public:
     // somebody has to re-evaluate once it comes down.
     void SetOnClose(std::function<void()> fn) { m_onClose = std::move(fn); }
 
+    // Whether the controller is actually being driven, and whether the tray
+    // toggle is the thing that decides it.
+    //
+    // Every setting in this window is inert while Steamless mode is off, and
+    // nothing on screen used to say so. That has now eaten three separate test
+    // sessions on #95 — settings changed, nothing happened, and the only place
+    // it was written down was the event log, which nobody reads while they are
+    // in the middle of testing.
+    //
+    // `manual` decides what can be offered about it: in manual mode the window
+    // can turn it on, and in the auto modes it is not the window's to change,
+    // so it says what does decide instead.
+    void SetControlState(bool enabled, bool manual);
+
+    // The user asked to turn Steamless mode on from inside the window. Routed
+    // back out rather than handled here: enabling means acquiring the device,
+    // which is the tray's business and carries the elevated-helper and retry
+    // handling with it.
+    void SetOnRequestEnable(std::function<void()> fn) { m_onRequestEnable = std::move(fn); }
+
 private:
     static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
     LRESULT HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
@@ -150,6 +170,11 @@ private:
     std::function<void(const std::wstring&, const ControllerProfile&)> m_applyCallback;
     std::function<void(const std::wstring&)> m_deleteCallback;
     std::function<void()> m_onClose;
+    std::function<void()> m_onRequestEnable;
+    // Mirrored so the banner can be drawn as soon as the page is ready, which
+    // is not the moment the state was last known.
+    bool m_controlEnabled = false;
+    bool m_controlManual  = true;
 
     Microsoft::WRL::ComPtr<ICoreWebView2Environment> m_env;
     Microsoft::WRL::ComPtr<ICoreWebView2Controller>  m_controller;

--- a/src/app/TrackpadConfig.h
+++ b/src/app/TrackpadConfig.h
@@ -83,7 +83,7 @@ inline ScrollDirection ScrollDirectionFromDword(uint32_t v) {
 // reads back as — which has to mean "unset", not "do not scroll at all".
 // ScrollSpeedFromDword maps it to the default rather than clamping it up.
 inline constexpr uint32_t kScrollSpeedDefault = 100;
-inline constexpr uint32_t kScrollSpeedMin     = 25;
+inline constexpr uint32_t kScrollSpeedMin     = 10;
 inline constexpr uint32_t kScrollSpeedMax     = 400;
 
 inline constexpr uint32_t ClampScrollSpeed(uint32_t v) {

--- a/src/app/TrackpadConfig.h
+++ b/src/app/TrackpadConfig.h
@@ -74,6 +74,28 @@ inline ScrollDirection ScrollDirectionFromDword(uint32_t v) {
          : ScrollDirection::Natural;
 }
 
+// How fast a pad in scroll mode scrolls, as a percentage of the built-in
+// scale. A taste setting: kCalibratedWheelLines in InputInjection.h already
+// makes a given swipe scroll the same distance on every machine, and this is
+// what remains for people who want that distance to be a different one.
+//
+// Stored as a DWORD, so 0 is what every profile written before this existed
+// reads back as — which has to mean "unset", not "do not scroll at all".
+// ScrollSpeedFromDword maps it to the default rather than clamping it up.
+inline constexpr uint32_t kScrollSpeedDefault = 100;
+inline constexpr uint32_t kScrollSpeedMin     = 25;
+inline constexpr uint32_t kScrollSpeedMax     = 400;
+
+inline constexpr uint32_t ClampScrollSpeed(uint32_t v) {
+    if (v < kScrollSpeedMin) return kScrollSpeedMin;
+    if (v > kScrollSpeedMax) return kScrollSpeedMax;
+    return v;
+}
+
+inline uint32_t ScrollSpeedFromDword(uint32_t v) {
+    return v == 0 ? kScrollSpeedDefault : ClampScrollSpeed(v);
+}
+
 // Whether a directional pad's diagonals press two directions at once (what a
 // real d-pad does, and what makes diagonal movement in a game possible) or
 // resolve to the nearer single direction (steadier for menus). Eight-way is
@@ -205,6 +227,8 @@ inline constexpr int kPadPressFrames = 2;
 struct TrackpadSettings {
     TrackpadMode      mode      = TrackpadMode::None;
     ScrollDirection   scrollDir = ScrollDirection::Natural;
+    // ScrollWheel only, as a percentage — see kScrollSpeedDefault.
+    uint32_t          scrollSpeed = kScrollSpeedDefault;
     BackButtonBinding click     = BackButtonBinding::FromAction(BackButtonAction::None);
     // Fires while a finger rests on the pad, whatever the pad's mode is doing
     // with movement. Deliberately not zoned like the click: touch and click
@@ -223,6 +247,7 @@ struct TrackpadSettings {
 
     bool operator==(const TrackpadSettings& o) const {
         return mode == o.mode && scrollDir == o.scrollDir && click == o.click
+            && scrollSpeed == o.scrollSpeed
             && touch == o.touch && up == o.up && down == o.down
             && left == o.left && right == o.right && diagonals == o.diagonals;
     }

--- a/src/app/TrackpadInput.cpp
+++ b/src/app/TrackpadInput.cpp
@@ -97,6 +97,26 @@ void TrackpadInput::UpdatePointer(int dx, int dy) {
     }
 }
 
+// The wheel units one frame of movement is worth.
+//
+// Two corrections sit on top of the built-in scale, and they answer different
+// questions. The first is not a preference at all: Windows multiplies every
+// notch we send by the machine's lines-per-notch setting before anything
+// moves, so the same swipe scrolls three times as far on a machine set to 10
+// as on one left at the default 3. Dividing it back out is what makes the pad
+// behave the same everywhere, and it is why a scroll-is-far-too-fast report
+// can be true on one machine and not reproduce on another with identical code.
+//
+// The second is the user's own scroll speed, which is taste and nothing else.
+// It is applied after the correction so the percentage means the same thing on
+// every machine: 100% is the calibrated feel, not "whatever this machine does".
+float TrackpadInput::ScrollScale() const {
+    const float correction =
+        InputInjection::WheelCorrection(InputInjection::WheelLinesPerNotch());
+    return SCROLL_SENSITIVITY * correction
+         * (static_cast<float>(m_scrollSpeed) / 100.0f);
+}
+
 // Wheel events are quantised to WHEEL_DELTA notches, which is much coarser
 // than a pad frame's movement — so the same remainder-carry the pointer path
 // uses is what makes slow scrolling work at all here.
@@ -108,8 +128,12 @@ void TrackpadInput::UpdatePointer(int dx, int dy) {
 void TrackpadInput::UpdateScroll(int dx, int dy) {
     if (m_scrollDir == ScrollDirection::Natural) { dx = -dx; dy = -dy; }
 
-    const float fy = static_cast<float>(dy) * SCROLL_SENSITIVITY + m_scrollRemY;
-    const float fx = static_cast<float>(dx) * SCROLL_SENSITIVITY + m_scrollRemX;
+    // The remainder carries in wheel units, which is what lets the scale change
+    // underneath it — a slider moved mid-swipe, or the system setting changing
+    // — without the part already banked meaning something different.
+    const float scale = ScrollScale();
+    const float fy = static_cast<float>(dy) * scale + m_scrollRemY;
+    const float fx = static_cast<float>(dx) * scale + m_scrollRemX;
     const LONG  iy = static_cast<LONG>(fy);
     const LONG  ix = static_cast<LONG>(fx);
     m_scrollRemY = fy - static_cast<float>(iy);

--- a/src/app/TrackpadInput.h
+++ b/src/app/TrackpadInput.h
@@ -25,6 +25,9 @@ public:
     void SetPad(bool isLeftPad) { m_isLeftPad = isLeftPad; }
     void SetMode(TrackpadMode mode);
     void SetScrollDirection(ScrollDirection dir) { m_scrollDir = dir; }
+    // Percent of the calibrated scroll scale — see kScrollSpeedDefault.
+    // Clamped here rather than trusted, since it arrives from the registry.
+    void SetScrollSpeed(uint32_t percent) { m_scrollSpeed = ClampScrollSpeed(percent); }
     void SetDiagonals(DiagonalMode d);
 
     // `pressed` is whether the pad is being pressed, worked out from contact
@@ -48,6 +51,7 @@ public:
 
 private:
     void UpdatePointer(int dx, int dy);
+    float ScrollScale() const;
     void UpdateScroll(int dx, int dy);
     void NoteMovementSent(long px, bool haveCursor, long cursorX, long cursorY);
     // Resolves the eight- or four-way sector a press at this angle belongs to,
@@ -64,6 +68,7 @@ private:
     bool            m_isLeftPad = false;
     TrackpadMode    m_mode      = TrackpadMode::None;
     ScrollDirection m_scrollDir = ScrollDirection::Natural;
+    uint32_t        m_scrollSpeed = kScrollSpeedDefault;
     DiagonalMode    m_diagonals = DiagonalMode::EightWay;
 
     bool     m_touching  = false;

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -280,20 +280,8 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             // is the sole source of intent — record it and take the same
             // acquire/release path the auto modes use. A second click while an
             // acquisition is still cycling cancels it rather than restarting.
-            if (m_wantControl) {
-                ReleaseControl();
-            } else {
-                // Taking the device back from a running Steam needs the
-                // elevated helper. Settle the one-time UAC prompt on this
-                // click instead of letting it ambush the first cycle.
-                // Registered even when already elevated: every cycle goes
-                // through the helper now, so an elevated run needs the task
-                // just as much.
-                EnsureCycleTaskRegistered();
-                m_wantControl    = true;
-                m_acquireRetries = 0;
-                TryAcquireController();
-            }
+            if (m_wantControl) ReleaseControl();
+            else               EnableFromUser();
             break;
         case IDM_REMAP_BACK:
             OpenRemapWindow();
@@ -354,6 +342,14 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         ApplySteamState(steamState);
         return 0;
     }
+
+    case WM_CONTROLSTATE:
+        // Read here rather than carried in the message: by the time this
+        // arrives the state may have moved again, and the window wants the
+        // current answer, not the one that prompted the post.
+        m_remapWindow.SetControlState(m_controller->IsGameModeActive(),
+                                      m_autoMode == AutoMode::Manual);
+        return 0;
 
     case WM_ALERT: {
         if (!m_notificationsEnabled)
@@ -492,6 +488,23 @@ LRESULT TrayApp::HandleMessage(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     return DefWindowProcW(hwnd, msg, wp, lp);
 }
 
+
+// Turning Steamless mode on at the user's request, from the tray toggle or
+// from the remap window's banner. Both are the same intent and must take the
+// same path — the window offering a shortcut that skipped the helper
+// registration would move the UAC prompt to the first cycle, which is exactly
+// where it ambushes people.
+void TrayApp::EnableFromUser() {
+    // Taking the device back from a running Steam needs the elevated helper.
+    // Settle the one-time UAC prompt on this click instead of letting it
+    // ambush the first cycle. Registered even when already elevated: every
+    // cycle goes through the helper now, so an elevated run needs the task
+    // just as much.
+    EnsureCycleTaskRegistered();
+    m_wantControl    = true;
+    m_acquireRetries = 0;
+    TryAcquireController();
+}
 void TrayApp::SetAutoMode(AutoMode mode) {
     EventLog::Write("MODE: control mode set to %d "
                     "(0=manual 1=offWhileSteam 2=offOnlyInGame 3=offUnlessProfile)",
@@ -1453,6 +1466,12 @@ void TrayApp::OpenRemapWindow() {
     // foreground changes — so moving it would trade an unnoticeable delay for
     // a data race.
     RefreshSteamApps();
+    // The banner's enable button. Same path as the tray toggle, deliberately.
+    m_remapWindow.SetOnRequestEnable([this] { EnableFromUser(); });
+    // Whatever the state is right now, so the window does not open showing the
+    // last thing that happened to change.
+    m_remapWindow.SetControlState(m_controller->IsGameModeActive(),
+                                  m_autoMode == AutoMode::Manual);
 
     // The window fills its own picker, on a background thread: finding every
     // installed application runs to well over a second on an ordinary machine
@@ -1521,6 +1540,10 @@ void TrayApp::RemoveTrayIcon() {
 
 void TrayApp::UpdateTrayIcon(bool connected, bool gameModeActive, bool sharedHandle,
                              bool padUnavailable) {
+    // The remap window dims and explains itself when nothing is being driven,
+    // so it has to hear about this from wherever the state actually changes.
+    PostMessageW(m_hwnd, WM_CONTROLSTATE, 0, 0);
+
     if (padUnavailable) ShowViGEmBalloon();
     // Cleared only by a pad that actually came up, not by any notification
     // that happens to carry false. The acquire path notifies repeatedly within

--- a/src/app/TrayApp.cpp
+++ b/src/app/TrayApp.cpp
@@ -1872,6 +1872,7 @@ void TrayApp::LoadSettings() {
             pad.mode      = TrackpadModeFromDword(readDw(name(L"Mode").c_str(), 0));
             pad.click     = binding(L"Click", BackButtonAction::None);
             pad.scrollDir = ScrollDirectionFromDword(readDw(name(L"ScrollDir").c_str(), 0));
+            pad.scrollSpeed = ScrollSpeedFromDword(readDw(name(L"ScrollSpeed").c_str(), 0));
             pad.touch     = binding(L"Touch", BackButtonAction::None);
             pad.up        = binding(L"Up",    BackButtonAction::DPadUp);
             pad.down      = binding(L"Down",  BackButtonAction::DPadDown);
@@ -1948,6 +1949,7 @@ void TrayApp::SaveSettings() {
         writeDw(name(L"Mode").c_str(),      static_cast<DWORD>(pad.mode));
         writeDw(name(L"Click").c_str(),     pad.click.Pack());
         writeDw(name(L"ScrollDir").c_str(), static_cast<DWORD>(pad.scrollDir));
+        writeDw(name(L"ScrollSpeed").c_str(), pad.scrollSpeed);
         writeDw(name(L"Touch").c_str(),     pad.touch.Pack());
         writeDw(name(L"Up").c_str(),        pad.up.Pack());
         writeDw(name(L"Down").c_str(),      pad.down.Pack());

--- a/src/app/TrayApp.h
+++ b/src/app/TrayApp.h
@@ -152,6 +152,7 @@ private:
     void EvaluateControl();
     void ApplySteamState(SteamState state);
     void TryAcquireController(uint32_t stateWaitMs = 250);
+    void EnableFromUser();
     void ReleaseControl();
     void RecoverStrandedDevices();
     void WriteHeartbeat();
@@ -307,6 +308,10 @@ private:
     static constexpr UINT WM_TRAY           = WM_APP + 1;
     static constexpr UINT WM_STEAMSTATE     = WM_APP + 2;
     static constexpr UINT WM_ALERT          = WM_APP + 3;
+    // Posted rather than acted on directly: the controller notifies from its
+    // read thread, and the remap window is WebView2, which must only be
+    // touched on the UI thread.
+    static constexpr UINT WM_CONTROLSTATE   = WM_APP + 4;
     static constexpr UINT TRAY_UID          = 1;
     static constexpr UINT_PTR IDT_ACQUIRE         = 1;
     static constexpr UINT_PTR IDT_ACQUIRE_VERDICT = 2;

--- a/src/probe/TrackpadDirectionProbe.cpp
+++ b/src/probe/TrackpadDirectionProbe.cpp
@@ -32,12 +32,14 @@
 // what users will feel.
 
 #include "app/TrackpadInput.h"
+#include "app/InputInjection.h"
 #include "hid/HidDevice.h"
 #include "steam/SteamController.h"
 #include <algorithm>
 #include <atomic>
 #include <conio.h>
 #include <cstdio>
+#include <cmath>
 #include <cstring>
 #include <mutex>
 #include <string>
@@ -769,6 +771,40 @@ int RunChecks() {
         Check(pad.Directions() == DirNone, "29 bytes or fewer resolves nothing");
     }
 
+
+    // Scroll normalisation (#95). A machine's lines-per-notch setting
+    // multiplies every wheel event we send, so identical injection scrolls a
+    // different distance on two machines — which is how a scroll-is-far-too-
+    // fast report can be real and still not reproduce. The correction divides
+    // it back out.
+    //
+    // The property worth guarding is the first one: at the Windows default the
+    // correction is exactly 1.0, so turning normalisation on changed nothing
+    // for the machines that were already fine.
+    printf("\nScroll normalisation against the wheel-lines setting\n");
+    {
+        // Not "near" — windows.h defines that as a macro.
+        auto approx = [](float a, float b) { return std::fabs(a - b) < 0.0005f; };
+        Check(approx(InputInjection::WheelCorrection(3.0f), 1.0f),
+              "the Windows default is left exactly alone");
+        Check(approx(InputInjection::WheelCorrection(10.0f), 0.3f),
+              "10 lines per notch scrolls at 30%, undoing the 3.3x");
+        Check(approx(InputInjection::WheelCorrection(1.0f), 3.0f),
+              "1 line per notch is scaled up, not only down");
+        Check(approx(InputInjection::WheelCorrection(20.0f), 0.15f),
+              "a page-per-notch machine is damped hard");
+        // Guards the divide rather than the arithmetic: a system that reports
+        // nothing usable must leave the scale where it was, not send it to
+        // infinity.
+        Check(approx(InputInjection::WheelCorrection(0.0f), 1.0f),
+              "an unreadable setting corrects by 1.0");
+        Check(approx(InputInjection::WheelCorrection(-5.0f), 1.0f),
+              "a negative setting corrects by 1.0");
+        // The live reader feeds that function, so it must never hand it a
+        // value the guard has to catch.
+        Check(InputInjection::WheelLinesPerNotch() > 0.0f,
+              "this machine reports a usable lines-per-notch");
+    }
     printf("\n%s (%d failure(s))\n", g_failures ? "FAILED" : "All checks passed", g_failures);
     return g_failures ? 1 : 0;
 }

--- a/src/probe/TrackpadDirectionProbe.cpp
+++ b/src/probe/TrackpadDirectionProbe.cpp
@@ -772,6 +772,34 @@ int RunChecks() {
     }
 
 
+    // Scroll speed bounds (#95). The page has its own copy of these rules in
+    // clampSpeed, so the two have to agree — a value the page allows and this
+    // side rewrites shows up as a setting that will not stay put.
+    printf("\nScroll speed clamping\n");
+    {
+        // Zero is what the registry yields for every profile written before
+        // the setting existed. It has to read as "unset", not as "do not
+        // scroll" — a pad that silently stopped scrolling on upgrade would be
+        // a far worse bug than one that scrolls at the wrong speed.
+        Check(ScrollSpeedFromDword(0) == kScrollSpeedDefault,
+              "an absent value is the default, not zero");
+        Check(ScrollSpeedFromDword(100) == 100, "a normal value is kept");
+        Check(ScrollSpeedFromDword(kScrollSpeedMin) == kScrollSpeedMin,
+              "the minimum is kept");
+        Check(ScrollSpeedFromDword(kScrollSpeedMax) == kScrollSpeedMax,
+              "the maximum is kept");
+        Check(ScrollSpeedFromDword(1) == kScrollSpeedMin,
+              "below the minimum clamps up");
+        Check(ScrollSpeedFromDword(99999) == kScrollSpeedMax,
+              "above the maximum clamps down");
+        // A DWORD read from the registry can be anything at all.
+        Check(ScrollSpeedFromDword(0xFFFFFFFFu) == kScrollSpeedMax,
+              "a nonsense DWORD clamps rather than wrapping");
+        Check(kScrollSpeedMin <= kScrollSpeedDefault
+                  && kScrollSpeedDefault <= kScrollSpeedMax,
+              "the default sits inside the range");
+    }
+
     // Scroll normalisation (#95). A machine's lines-per-notch setting
     // multiplies every wheel event we send, so identical injection scrolls a
     // different distance on two machines — which is how a scroll-is-far-too-

--- a/src/probe/TrackpadDirectionProbe.cpp
+++ b/src/probe/TrackpadDirectionProbe.cpp
@@ -832,6 +832,21 @@ int RunChecks() {
         // value the guard has to catch.
         Check(InputInjection::WheelLinesPerNotch() > 0.0f,
               "this machine reports a usable lines-per-notch");
+        // The property the PADS log line depends on: correcting by
+        // 3/linesPerNotch and then having the machine multiply by
+        // linesPerNotch leaves kCalibratedWheelLines, whatever the machine is
+        // set to. That cancellation is why the speed setting alone says how
+        // fast a pad scrolls, and why reporting speed x correction as a "net"
+        // figure was wrong — it described the wheel units we send, not the
+        // distance anything moves.
+        for (float lines : {1.0f, 3.0f, 10.0f, 20.0f, 100.0f}) {
+            char label[96];
+            snprintf(label, sizeof(label),
+                     "at %.0f lines per notch the machine's own scaling cancels",
+                     static_cast<double>(lines));
+            Check(approx(InputInjection::WheelCorrection(lines) * lines,
+                         InputInjection::kCalibratedWheelLines), label);
+        }
     }
     printf("\n%s (%d failure(s))\n", g_failures ? "FAILED" : "All checks passed", g_failures);
     return g_failures ? 1 : 0;


### PR DESCRIPTION
Closes #95.

The reporter's trackpad scrolled far too fast in scroll mode, while Steam felt normal on the same machine. It turned out to be two separate things, and untangling them took several rounds because the diagnostics could not tell a failed test from a test that never ran.

## The bug

Scroll is injected as wheel events, and Windows multiplies every notch by the machine's lines-per-notch setting before anything moves. That setting is not ours, is not the same everywhere, and sits downstream of everything we do — so identical injection scrolled 3.3x further on his machine (10 lines per notch) than on one left at the Windows default of 3. It is why the report was entirely real and did not reproduce here.

`WheelCorrection` divides it back out, anchored at the default so the correction is exactly 1.0 on a machine nobody has touched. Confirmed from his log once the diagnostics could say so:

```
wheel=10 lines per notch (not the default 3), scroll scaled to 30%
```

## The trap

Every setting in Customize Controls is inert while Steamless mode is off, and nothing on screen said so. That ate three test sessions on this issue and produced two false "it's broken" reports — settings saved correctly, simply not driving anything. The window now says so, and offers to turn it on.

## What is here

| | |
|---|---|
| Normalise scroll against the machine's wheel setting | anchored at the Windows default, so default machines are untouched |
| Per-pad scroll speed | stops from 0.1x to 4x, shown only in scroll mode |
| `PADS:` log line | what the pads are set to, and whether anything is driving them |
| Installer staleness guard | refuses to package an executable whose version disagrees with the script |
| Off-state banner | with an Enable button in manual mode |

Two of these exist because of mistakes made while fixing the first. A 1.21.1 installer shipped carrying the 1.21 binary, because `cmake --build build/release` quietly produces Debug while the installer packages Release — hence the guard, and the release build preset now builds every binary the installer needs. And the `PADS` line first reported `speed x correction` as a "net % of calibrated", which is the multiplier on the wheel units we send and not what the scroll feels like; `linesPerNotch` cancels, so the speed setting alone is the answer, and `TrackpadDirectionProbe` now checks that cancellation at 1, 3, 10, 20 and 100 lines per notch.

## Verification

- `TrackpadDirectionProbe` and `BindingCodecProbe` pass; the former gained 20 checks covering the correction, the cancellation, and the speed clamp
- The page was driven in a real browser over HTTP: every slider stop, the wire round trip, out-of-range and legacy values, and all four banner states through the host message path
- Scroll speed confirmed working on hardware with Steamless mode on, at both ends of the range
- Built with `cmake --build --preset release`; the packaged binary was checked to stamp 1.22 and to contain the new strings

## Not addressed

The jump hypothesis — that the pad occasionally reports impossible movement — is finally ruled out for this reporter, but only after two rounds of logs that could not answer it. The `TRACKPAD:` diagnostic that would catch it remains, unfired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)